### PR TITLE
Update repo location

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: LicenseRef-MIT-TQ
 
 ## Reporting Issues
 
-Please [open an issue](https://github.com/tqtezos/baseDAO/issues/new)
+Please [open an issue](https://github.com/tezos-commons/baseDAO/issues/new)
 if you find a bug or have a feature request.
 Before submitting a bug report or feature request, check to make sure it hasn't already been submitted.
 

--- a/.xrefcheck.yaml
+++ b/.xrefcheck.yaml
@@ -36,7 +36,7 @@ verification:
     - .gitlab/issue_templates/
 
     # This file is ignored because it refers to
-    # https://github.com/tqtezos/baseDAO/issues/new
+    # https://github.com/tezos-commons/baseDAO/issues/new
     # which requires a github account with access to the repo
     # (xrefcheck itself doesn't have it)
     - .github/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ well, there are also the [included DAOs](#included-daos) below.
 
 BaseDAO is implemented in [LIGO](https://ligolang.org), you can obtain the
 compiled contract as well as the initial storage for all the [included DAOs](#included-daos)
-from the [latest release](https://github.com/tqtezos/baseDAO/releases/latest)
+from the [latest release](https://github.com/tezos-commons/baseDAO/releases/latest)
 or build them from source by following the [building instructions](docs/building.md).
 
 ## Included DAOs

--- a/haskell/baseDAO-ligo-meta.cabal
+++ b/haskell/baseDAO-ligo-meta.cabal
@@ -18,7 +18,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: git@github.com:tqtezos/baseDAO.git
+  location: git@github.com:tezos-commons/baseDAO.git
 
 library
   exposed-modules:

--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -6,7 +6,7 @@ version:             0.3.1.0
 license:             MIT
 license-file:        LICENSE
 author:              Serokell, Tocqueville Group
-git:                 git@github.com:tqtezos/baseDAO.git
+git:                 git@github.com:tezos-commons/baseDAO.git
 copyright:           2021 TQ Tezos
 
 extra-source-files:

--- a/haskell/src/Ligo/BaseDAO/TZIP16Metadata.hs
+++ b/haskell/src/Ligo/BaseDAO/TZIP16Metadata.hs
@@ -60,7 +60,7 @@ knownBaseDAOMetadata settings = mconcat
   [ version . fromString $ showVersion Paths.version
   , license $ License "MIT" Nothing
   , authors [Author "Serokell", Author "Tocqueville Group"]
-  , homepage "https://github.com/tqtezos/baseDAO"
+  , homepage "https://github.com/tezos-commons/baseDAO"
   , interfaces [tzip 17]
   , views (baseDAOViews settings)
   ]

--- a/haskell/test/SMT/Common/Run.hs
+++ b/haskell/test/SMT/Common/Run.hs
@@ -250,7 +250,7 @@ callLigoEntrypoint mc dao = withSender (mc & mcSource & msoSender) $ case mc & m
 
 
 -- TODO: Use `fromExpression` instead when new morley version is updated.
--- More detail: https://github.com/tqtezos/baseDAO/pull/282#discussion_r669572842
+-- More detail: https://github.com/tezos-commons/baseDAO/pull/282#discussion_r669572842
 parseNettestError :: Either NettestFailure a -> Maybe ModelError
 parseNettestError = \case
   Right _ -> Nothing

--- a/scripts/ci/upload-autodoc.sh
+++ b/scripts/ci/upload-autodoc.sh
@@ -9,7 +9,7 @@ set -e -o pipefail
 git config --global user.email "hi@serokell.io"
 git config --global user.name "CI autodoc generator"
 git remote remove auth-origin 2> /dev/null || :
-git remote add auth-origin https://serokell:$AUTODOC_TOKEN@github.com/tqtezos/baseDAO.git
+git remote add auth-origin https://serokell:$AUTODOC_TOKEN@github.com/tezos-commons/baseDAO.git
 git fetch
 
 our_branch="$BUILDKITE_BRANCH"


### PR DESCRIPTION
## Description

Problem: The BaseDAO repo has been moved to tezos-commons organization
so the repo url has been changed.

Solution: We update the references to repo in the source and
documentation.