### PR TITLE
[#68] Add a stress test for the number of proposals

### DIFF
--- a/haskell/test/Test/Ligo/BaseDAO/Common.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Common.hs
@@ -43,6 +43,7 @@ import Named ((!))
 
 import Ligo.BaseDAO.Contract
 import Ligo.BaseDAO.Types
+import Ligo.Util
 import Test.Ligo.BaseDAO.Common.Errors as Errors
 import Test.Ligo.BaseDAO.Common.StorageHelper as StorageHelper
 import Test.Ligo.BaseDAO.Proposal.Config (ConfigDesc, fillConfig)
@@ -164,6 +165,7 @@ originateLigoDaoWithConfig extra config qt = do
   tokenContract <- chAddress <$> originateSimple "TokenContract" [] dummyFA2Contract
   guardianContract <- chAddress <$> originateSimple "guardian" () dummyGuardianContract
 
+
   let fullStorage = FullStorage
         { fsStorage =
             ( mkStorage
@@ -182,6 +184,7 @@ originateLigoDaoWithConfig extra config qt = do
             }
         , fsConfig = config
         }
+  --let fullStorage'' = fromVal @FullStorage ($(fetchValue @FullStorage "/tmp/storage-1.tz" "__"))
   let
     originateData = UntypedOriginateData
       { uodName = "BaseDAO"

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -173,4 +173,10 @@ test_BaseDAO_Proposal =
       , nettestScenarioCaps "proposal saves quorum for cycle" $
           checkProposalSavesQuorum (originateLigoDaoWithConfigDesc dynRecUnsafe)
       ]
+
+  , testGroup "Stress tests:"
+      [ nettestScenarioCaps "proposals creation scales adequetly" $
+          proposalStressTest (originateLigoDaoWithConfigDesc dynRecUnsafe)
+      ]
+
   ]

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -9,7 +9,7 @@ module Test.Ligo.BaseDAO.Proposal
 import Lorentz hiding (assert, (>>))
 import Universum
 
-import Morley.Nettest.Tasty (nettestScenarioCaps)
+import Morley.Nettest.Tasty (nettestScenarioCaps, nettestScenarioOnEmulatorCaps)
 import Test.Tasty (TestTree, testGroup)
 
 import Ligo.BaseDAO.Types
@@ -175,8 +175,11 @@ test_BaseDAO_Proposal =
       ]
 
   , testGroup "Stress tests:"
-      [ nettestScenarioCaps "proposals creation scales adequetly" $
+      [ nettestScenarioOnEmulatorCaps "proposals creation scales adequetly" $
+          proposalStressTest_ (originateLigoDaoWithConfigDesc dynRecUnsafe)
+      , nettestScenarioCaps "proposals creation scales adequetly using preloaded storage" $
           proposalStressTest (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
       ]
 
   ]


### PR DESCRIPTION
## Description

Adds a stress test to check that the contract can handle a thousand proposals without getting locked.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #68 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
