### PR TITLE
[#259] Unsort Haskell constructors

### DIFF
--- a/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/haskell/src/Ligo/BaseDAO/Types.hs
@@ -509,19 +509,13 @@ type CustomEntrypoint = (MText, ByteString)
 type FreezeParam = ("amount" :! Natural)
 type UnfreezeParam = ("amount" :! Natural)
 
--- NOTE: Constructors of the parameter types should remain sorted for the
---'ligoLayout' custom derivation to work.
---
--- TODO #259: The comment above should no longer be the case since the following
--- issue has been fixed:
--- https://gitlab.com/morley-framework/morley/-/issues/527
 data ForbidXTZParam
   = Drop_proposal ProposalKey
+  | Vote [PermitProtected VoteParam]
   | Flush Natural
   | Freeze FreezeParam
   | Unfreeze UnfreezeParam
   | Update_delegate [DelegateParam]
-  | Vote [PermitProtected VoteParam]
   deriving stock (Eq, Show)
 
 instance Buildable ForbidXTZParam where
@@ -547,10 +541,10 @@ instance Buildable Parameter where
   build = genericF
 
 data AddressFreezeHistory = AddressFreezeHistory
-  { fhCurrentUnstaked :: Natural
-  , fhPastUnstaked :: Natural
-  , fhCurrentStageNum :: Natural
+  { fhCurrentStageNum :: Natural
   , fhStaked :: Natural
+  , fhCurrentUnstaked :: Natural
+  , fhPastUnstaked :: Natural
   } deriving stock (Eq, Show)
 
 instance Buildable AddressFreezeHistory where
@@ -568,8 +562,8 @@ customGeneric "GovernanceToken" ligoLayout
 deriving anyclass instance IsoValue GovernanceToken
 
 data QuorumThresholdAtCycle = QuorumThresholdAtCycle
-  { qaLastUpdatedCycle :: Natural
-  , qaQuorumThreshold :: QuorumThreshold
+  { qaQuorumThreshold :: QuorumThreshold
+  , qaLastUpdatedCycle :: Natural
   , qaStaked :: Natural
   } deriving stock (Eq, Show)
 
@@ -663,7 +657,7 @@ mkStorage admin extra metadata lvl tokenAddress qt =
     , sFreezeHistory = mempty
     , sStartLevel = arg #level lvl
     , sFrozenTokenId = frozenTokenId
-    , sQuorumThresholdAtCycle = QuorumThresholdAtCycle 1 (arg #quorumThreshold qt) 0
+    , sQuorumThresholdAtCycle = QuorumThresholdAtCycle (arg #quorumThreshold qt) 1 0
     , sFrozenTotalSupply = 0
     , sDelegates = mempty
     }

--- a/haskell/test/SMT/Common/Gen.hs
+++ b/haskell/test/SMT/Common/Gen.hs
@@ -166,7 +166,7 @@ genQuorumThresholdAtCycle :: Natural -> GeneratorT QuorumThresholdAtCycle
 genQuorumThresholdAtCycle staked = do
   quorumThreshold <- Gen.integral (Range.constant 1 3)
   lvl <- get <&> gsLevel
-  pure $ QuorumThresholdAtCycle lvl quorumThreshold staked
+  pure $ QuorumThresholdAtCycle quorumThreshold lvl staked
 
 genModelState :: SmtOption -> GeneratorT (Address -> Address -> ModelState)
 genModelState SmtOption{..} = do

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Flush.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Flush.hs
@@ -73,9 +73,19 @@ flushAcceptedProposals originateFn = do
 
   -- Checking freezing histories of proposer and voters
   fhOwner1 <- getFreezeHistory dodDao dodOwner1
-  fhOwner1 @== Just (AddressFreezeHistory 0 0 1 10)
+  fhOwner1 @== Just AddressFreezeHistory
+    { fhCurrentStageNum = 1
+    , fhStaked = 10
+    , fhCurrentUnstaked = 0
+    , fhPastUnstaked = 0
+    }
   fhOwner2 <- getFreezeHistory dodDao dodOwner2
-  fhOwner2 @== Just (AddressFreezeHistory 0 0 2 15)
+  fhOwner2 @== Just AddressFreezeHistory
+    { fhCurrentStageNum  = 2
+    , fhStaked = 15
+    , fhCurrentUnstaked = 0
+    , fhPastUnstaked = 0
+    }
 
   -- Advance one voting period to a proposing stage.
   proposalStart <- getProposalStartLevel dodDao key1
@@ -85,9 +95,19 @@ flushAcceptedProposals originateFn = do
   checkIfAProposalExist key1 dodDao False
 
   fhOwner1' <- getFreezeHistory dodDao dodOwner1
-  fhOwner1' @== Just (AddressFreezeHistory 0 10 3 0)
+  fhOwner1' @== Just AddressFreezeHistory
+    { fhCurrentStageNum = 3
+    , fhStaked = 0
+    , fhCurrentUnstaked = 0
+    , fhPastUnstaked = 10
+    }
   fhOwner2' <- getFreezeHistory dodDao dodOwner2
-  fhOwner2' @== Just (AddressFreezeHistory 0 15 3 0)
+  fhOwner2' @== Just AddressFreezeHistory
+    { fhCurrentStageNum = 3
+    , fhStaked = 0
+    , fhCurrentUnstaked = 0
+    , fhPastUnstaked = 15
+    }
 
 flushAcceptedProposalsWithAnAmount
   :: (MonadNettest caps base m, HasCallStack)

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Propose.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Propose.hs
@@ -82,7 +82,12 @@ validProposal originateFn = do
 
   -- Check freeze history
   fh <- getFreezeHistory dodDao dodOwner1
-  fh @== Just (AddressFreezeHistory 0 0 1 10)
+  fh @== Just AddressFreezeHistory
+    { fhCurrentStageNum = 1
+    , fhStaked = 10
+    , fhCurrentUnstaked = 0
+    , fhPastUnstaked = 0
+    }
 
 validProposalWithFixedFee
   :: forall caps base m. (MonadNettest caps base m, HasCallStack)
@@ -108,7 +113,12 @@ validProposalWithFixedFee = do
   supply <- getFrozenTotalSupply dodDao
   supply @== 52
   fh <- getFreezeHistory dodDao dodOwner1
-  fh @== Just (AddressFreezeHistory 0 0 1 52)
+  fh @== Just AddressFreezeHistory
+    { fhCurrentStageNum = 1
+    , fhStaked = 52
+    , fhCurrentUnstaked = 0
+    , fhPastUnstaked = 0
+    }
 
 proposerIsReturnedFeeAfterSucceeding
   :: forall caps base m. (MonadNettest caps base m, HasCallStack)

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Quorum.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Quorum.hs
@@ -74,7 +74,7 @@ checkQuorumThresholdDynamicUpdate originateFn = do
     call dodDao (Call @"Propose") (ProposeParams proposer requiredFrozen proposalMeta1)
 
   quorumThresholdActual_ <- getQtAtCycle dodDao
-  let quorumThresholdExpected_ = QuorumThresholdAtCycle 1 (mkQuorumThreshold 3 10) 10
+  let quorumThresholdExpected_ = QuorumThresholdAtCycle (mkQuorumThreshold 3 10) 1 10
   assert (quorumThresholdActual_ == quorumThresholdExpected_) "Unexpected quorumThreshold update"
 
   -- skip this proposal period and next voting period to be in next proposal period
@@ -89,7 +89,7 @@ checkQuorumThresholdDynamicUpdate originateFn = do
   -- participation = 10/100 = 1/10
   -- so possible_new_quorum = 3/10 * (1 - 0.05)  + (1/10 * 5/100)
   -- so 3/10 * (19/20) + (5/1000) = 57/200 + 1/200 = 58/200 = 29/100
-  let quorumThresholdExpected = QuorumThresholdAtCycle 2 (calculateThreshold 19 5 100 10 $ mkQuorumThreshold 3 10) 10
+  let quorumThresholdExpected = QuorumThresholdAtCycle (calculateThreshold 19 5 100 10 $ mkQuorumThreshold 3 10) 2 10
   assert (quorumThresholdActual == quorumThresholdExpected) "Unexpected quorumThreshold after update"
 
 checkQuorumThresholdDynamicUpdateUpperBound
@@ -134,7 +134,7 @@ checkQuorumThresholdDynamicUpdateUpperBound originateFn = do
   --
   -- min_quorum = (3/10) / 1.07 = 0.28
   -- max_quorum = (3/10) * (107/100) = 321/1000 = 0.321
-  let quorumThresholdExpected = QuorumThresholdAtCycle 2 (calculateThreshold 7 5 100 100 $ mkQuorumThreshold 3 10) 100
+  let quorumThresholdExpected = QuorumThresholdAtCycle (calculateThreshold 7 5 100 100 $ mkQuorumThreshold 3 10) 2 100
   assert (quorumThresholdActual == quorumThresholdExpected) "Unexpected quorumThreshold after update"
 
 checkQuorumThresholdDynamicUpdateLowerBound
@@ -179,7 +179,7 @@ checkQuorumThresholdDynamicUpdateLowerBound originateFn = do
   --
   -- min_quorum = (3/10) / (119/100) = 300/1190 = 0.2521
   -- let expected = QuorumThresholdAtCycle 2 (mkQuorumThreshold 300 1190) 100
-  let quorumThresholdExpected = QuorumThresholdAtCycle 2 (calculateThreshold 19 25 100 100 $ mkQuorumThreshold 3 10) 100
+  let quorumThresholdExpected = QuorumThresholdAtCycle (calculateThreshold 19 25 100 100 $ mkQuorumThreshold 3 10) 2 100
   assert (quorumThresholdActual == quorumThresholdExpected) "Unexpected quorumThreshold after update"
 
 checkProposalSavesQuorum


### PR DESCRIPTION
## Description

Problem: We have some comment that cautions agaist changing the ordering
of constructors of the Haskell contract parameter. But this is outdated
as the issue causing it have been fixed.

Solution: Change the sort order of constructors and check that tests
pass. Remove the respective comments and TODO.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #259 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
