### PR TITLE
[Chore] Remove tests from CI for protocol 010

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -87,9 +87,9 @@ steps:
     artifact_paths:
       - known_metadata.json
 
-  - label: ligo-test-local-chain-010
+  - label: ligo-test-local-chain-011
     env:
-      TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8733"
+      TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8734"
     if: *not_scheduled
     depends_on:
       - build-ligo
@@ -102,18 +102,6 @@ steps:
     - export TASTY_NETTEST_DATA_DIR="$(mktemp -d --tmpdir="$$PWD")"
     - nix run -f ci.nix tezos-client -c
       ./result/bin/baseDAO-test
-
-  - label: ligo-test-local-chain-011
-    env:
-      TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8734"
-    if: *not_scheduled
-    depends_on:
-      - build-ligo
-      - build-haskell
-      - ligo-test
-      # NOTE ^ this last dependency is not strictly necessary, but it saves us
-      # from building the tests twice and 'ligo-test' running time is mostly that.
-    commands: *ligo-nettest
 
   - label: check typescript api
     if: *not_scheduled
@@ -144,18 +132,6 @@ steps:
     depends_on: build-haskell
     commands:
     - nix-build ci.nix -A haddock --no-out-link
-
-  - label: scheduled granadanet ligo test
-    if: build.source == "schedule"
-    env:
-      TASTY_NETTEST_NODE_ENDPOINT: "https://granada.testnet.tezos.serokell.team"
-    depends_on:
-      - build-ligo
-      - build-haskell
-    commands: *ligo-nettest
-    retry:
-      automatic:
-        limit: 1
 
   - label: scheduled hangzhounet ligo test
     if: build.source == "schedule"


### PR DESCRIPTION
## Description

The granada/010 protocol is no longer active on mainnet and its testnet is no longer relevant to us.

This removes the tests on CI based on said protocol

## Related issue(s)

[TM-603](https://issues.serokell.io/issue/TM-603)

## :white_check_mark: Checklist for your Merge Request

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
