### PR TITLE
[#311] Remove voters limit and avoid returning tokens on flush 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ $(OUT)/trivialDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/trivialDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/trivialDAO_storage.tz : min_quorum = 1n
 $(OUT)/trivialDAO_storage.tz : max_quorum = 99n
-$(OUT)/trivialDAO_storage.tz : max_voters = 1000n
 $(OUT)/trivialDAO_storage.tz : period = 15840n
 $(OUT)/trivialDAO_storage.tz : quorum_change = 5n
 $(OUT)/trivialDAO_storage.tz : max_quorum_change = 19n
@@ -88,7 +87,6 @@ $(OUT)/trivialDAO_storage.tz: src/**
         ; config_data = \
           { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
           ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
-          ; max_voters = ($(max_voters) : nat) \
           ; period = { blocks = ($(period) : nat) } \
           ; proposal_flush_level = { blocks = ($(proposal_flush_level) : nat) } \
           ; proposal_expired_level = { blocks = ($(proposal_expired_level) : nat) }\
@@ -116,7 +114,6 @@ $(OUT)/registryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/registryDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/registryDAO_storage.tz : min_quorum = 1n
 $(OUT)/registryDAO_storage.tz : max_quorum = 99n
-$(OUT)/registryDAO_storage.tz : max_voters = 1000n
 $(OUT)/registryDAO_storage.tz : period = 15840n
 $(OUT)/registryDAO_storage.tz : quorum_change = 5n
 $(OUT)/registryDAO_storage.tz : max_quorum_change = 19n
@@ -143,7 +140,6 @@ $(OUT)/registryDAO_storage.tz: src/**
           ; config_data = \
             { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
             ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
-            ; max_voters = ($(max_voters) : nat) \
             ; period = { blocks = ($(period) : nat) } \
             ; proposal_flush_level = { blocks = ($(proposal_flush_level) : nat) } \
             ; proposal_expired_level = { blocks = ($(proposal_expired_level) : nat) } \
@@ -178,7 +174,6 @@ $(OUT)/treasuryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/treasuryDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/treasuryDAO_storage.tz : min_quorum = 1n
 $(OUT)/treasuryDAO_storage.tz : max_quorum = 99n
-$(OUT)/treasuryDAO_storage.tz : max_voters = 1000n
 $(OUT)/treasuryDAO_storage.tz : period = 15840n
 $(OUT)/treasuryDAO_storage.tz : quorum_change = 5n
 $(OUT)/treasuryDAO_storage.tz : max_quorum_change = 19n
@@ -205,7 +200,6 @@ $(OUT)/treasuryDAO_storage.tz: src/**
           ; config_data = \
             { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
             ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
-            ; max_voters = ($(max_voters) : nat) \
             ; period = { blocks = ($(period) : nat) } \
             ; proposal_flush_level = { blocks = ($(proposal_flush_level) : nat) } \
             ; proposal_expired_level = { blocks = ($(proposal_expired_level) : nat) } \

--- a/docs/building.md
+++ b/docs/building.md
@@ -86,7 +86,6 @@ make out/trivialDAO_storage.tz \
   quorum_threshold=10n \
   min_quorum=1n \
   max_quorum=99n \
-  max_voters=1000n \
   period=15840n  \
   quorum_change=5n \
   max_quorum_change=19n \
@@ -126,7 +125,6 @@ make out/registryDAO_storage.tz \
   quorum_threshold=10n \
   min_quorum=1n \
   max_quorum=99n \
-  max_voters=1000n \
   period=15840n \
   quorum_change=5n \
   max_quorum_change=19n \
@@ -164,7 +162,6 @@ make out/treasuryDAO_storage.tz \
   quorum_threshold=10n \
   min_quorum=1n \
   max_quorum=99n \
-  max_voters=1000n \
   period=15840n  \
   quorum_change=5n \
   max_quorum_change=19n \

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -24,7 +24,6 @@ Here is a summary of all the error codes thrown by the contract.
 | 103 | `proposal_not_exist` | The proposal does not exist or is no longer ongoing. |
 | 104 | `voting_stage_over` | The proposal voting stage has already ended. |
 | 105 | `max_proposals_reached` | The maximum amount of ongoing proposals has been reached. |
-| 106 | `max_voters_reached` | The maximum amount of voters has been reached for the proposal. |
 | 107 | `forbidden_xtz` | Transfer of XTZ is forbidden on this entrypoint. |
 | 108 | `proposal_not_unique` | The submitted proposal already exist. |
 | 109 | `missigned` | Parameter signature does not match the expected one - for permits. |
@@ -41,6 +40,8 @@ Here is a summary of all the error codes thrown by the contract.
 | 120 | `not_delegate` | The sender has not been delegated the control of the required tokens. |
 | 121 | `fail_decision_lambda` | Executing the proposal's decision lambda results in failure. |
 | 122 | `entrypoint_not_found` | The chosen custom entrypoint does not exist. |
+| 123 | `unstake_invalid_proposal` | Cannot call `unstake_vote` on the proposal that is not flushed or dropped. |
+| 124 | `voter_does_not_exist` | The sender did not vote on the proposal or already unstaked tokens from the proposal. |
 
 
 

--- a/haskell/src/Ligo/BaseDAO/ErrorCodes.hs
+++ b/haskell/src/Ligo/BaseDAO/ErrorCodes.hs
@@ -43,10 +43,6 @@ votingStageOver = 104
 maxProposalsReached :: Natural
 maxProposalsReached = 105
 
--- | The maximum amount of voters has been reached for the proposal.
-maxVotersReached :: Natural
-maxVotersReached = 106
-
 -- | Transfer of XTZ is forbidden on this entrypoint.
 forbiddenXtz :: Natural
 forbiddenXtz = 107
@@ -111,6 +107,14 @@ failDecisionLambda = 121
 entrypointNotFound :: Natural
 entrypointNotFound = 122
 
+-- | Cannot call `unstake_vote` on the proposal that is not flushed or dropped.
+unstakeInvalidProposal :: Natural
+unstakeInvalidProposal = 123
+
+-- | The sender did not vote on the proposal or already unstaked tokens from the proposal.
+voterDoesNotExist :: Natural
+voterDoesNotExist = 124
+
 
 
 
@@ -165,12 +169,6 @@ tzipErrorList = [
   EStatic $ StaticError
     { seError = toExpression $ toVal @Integer $ toInteger maxProposalsReached
     , seExpansion = toExpression $ toVal @MText [mt|The maximum amount of ongoing proposals has been reached.|]
-    , seLanguages = ["en"]
-    }
-  ,
-  EStatic $ StaticError
-    { seError = toExpression $ toVal @Integer $ toInteger maxVotersReached
-    , seExpansion = toExpression $ toVal @MText [mt|The maximum amount of voters has been reached for the proposal.|]
     , seLanguages = ["en"]
     }
   ,
@@ -267,6 +265,18 @@ tzipErrorList = [
   EStatic $ StaticError
     { seError = toExpression $ toVal @Integer $ toInteger entrypointNotFound
     , seExpansion = toExpression $ toVal @MText [mt|The chosen custom entrypoint does not exist.|]
+    , seLanguages = ["en"]
+    }
+  ,
+  EStatic $ StaticError
+    { seError = toExpression $ toVal @Integer $ toInteger unstakeInvalidProposal
+    , seExpansion = toExpression $ toVal @MText [mt|Cannot call `unstake_vote` on the proposal that is not flushed or dropped.|]
+    , seLanguages = ["en"]
+    }
+  ,
+  EStatic $ StaticError
+    { seError = toExpression $ toVal @Integer $ toInteger voterDoesNotExist
+    , seExpansion = toExpression $ toVal @MText [mt|The sender did not vote on the proposal or already unstaked tokens from the proposal.|]
     , seLanguages = ["en"]
     }
   ,

--- a/haskell/test/SMT/Common/Run.hs
+++ b/haskell/test/SMT/Common/Run.hs
@@ -254,6 +254,7 @@ callLigoEntrypoint mc dao = withSender (mc & mcSource & msoSender) $ case mc & m
   XtzForbidden (Unfreeze p) -> call dao (Call @"Unfreeze") p
   XtzForbidden (Update_delegate p) -> call dao (Call @"Update_delegate") p
   XtzForbidden (Drop_proposal p) -> call dao (Call @"Drop_proposal") p
+  XtzForbidden (Unstake_vote p) -> call dao (Call @"Unstake_vote") p
 
   XtzAllowed (CallCustom p) -> call dao (Call @"CallCustom") p
 

--- a/haskell/test/SMT/Model/BaseDAO/Contract.hs
+++ b/haskell/test/SMT/Model/BaseDAO/Contract.hs
@@ -41,3 +41,4 @@ handleCallViaHaskell mc ms =
         XtzForbidden (Unfreeze p) -> applyUnfreeze (mc & mcSource) p
         XtzForbidden (Update_delegate p) -> applyUpdateDelegate (mc & mcSource) p
         XtzForbidden (Drop_proposal p) -> applyDropProposal (mc & mcSource) p
+        XtzForbidden (Unstake_vote p) -> applyUnstakeVote (mc & mcSource) p

--- a/haskell/test/SMT/Model/BaseDAO/Types.hs
+++ b/haskell/test/SMT/Model/BaseDAO/Types.hs
@@ -211,7 +211,6 @@ data ModelError
   | PROPOSAL_NOT_EXIST
   | EXPIRED_PROPOSAL
   | MISSIGNED
-  | MAX_VOTERS_REACHED
   | VOTING_STAGE_OVER
   | DROP_PROPOSAL_CONDITION_NOT_MET
   | NOT_ADMIN
@@ -221,6 +220,8 @@ data ModelError
   | UNPACKING_FAILED
   | FAIL_PROPOSAL_CHECK
   | MISSING_VALUE
+  | UNSTAKE_INVALID_PROPOSAL
+  | VOTER_DOES_NOT_EXIST
   deriving stock (Generic, Eq, Show)
 
 instance Buildable ModelError where
@@ -248,4 +249,6 @@ contractErrorToModelError errorCode
   | (errorCode == toInteger entrypointNotFound) = ENTRYPOINT_NOT_FOUND
   | (errorCode == toInteger unpackingFailed) = UNPACKING_FAILED
   | (errorCode == toInteger failProposalCheck) = FAIL_PROPOSAL_CHECK
+  | (errorCode == toInteger unstakeInvalidProposal) = UNSTAKE_INVALID_PROPOSAL
+  | (errorCode == toInteger voterDoesNotExist) = VOTER_DOES_NOT_EXIST
   | otherwise = error $ toText $ show errorCode

--- a/haskell/test/SMT/TreasuryDAO.hs
+++ b/haskell/test/SMT/TreasuryDAO.hs
@@ -3,7 +3,7 @@
 
 module SMT.TreasuryDAO
   ( hprop_TreasuryDaoSMT
-  )  where
+  ) where
 
 import Universum hiding (drop, swap)
 

--- a/haskell/test/Test/Ligo/BaseDAO/Common/StorageHelper.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Common/StorageHelper.hs
@@ -10,6 +10,7 @@ module Test.Ligo.BaseDAO.Common.StorageHelper
   , getFullStorage
   , getProposal
   , getProposalStartLevel
+  , getVoter
   , getQtAtCycle
   , getStorageRPC
   , getVotePermitsCounter
@@ -47,6 +48,15 @@ getProposal
 getProposal addr pKey = do
   bId <- (sProposalsRPC . fsStorageRPC) <$> getStorageRPC addr
   getBigMapValueMaybe bId pKey
+
+getVoter
+  :: forall p base caps m. MonadCleveland caps base m
+  => TAddress p
+  -> (Address, ProposalKey)
+  -> m (Maybe StakedVote)
+getVoter addr key = do
+  bId <- (sStakedVotesRPC . fsStorageRPC) <$> getStorageRPC addr
+  getBigMapValueMaybe bId key
 
 getProposalStartLevel
   :: forall p base caps m. MonadCleveland caps base m

--- a/haskell/test/Test/Ligo/BaseDAO/ErrorCode.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/ErrorCode.hs
@@ -22,7 +22,6 @@ test_ErrorCodes = testGroup "FA2 off-chain views"
       proposalNotExist @?= 103
       votingStageOver @?= 104
       maxProposalsReached @?= 105
-      maxVotersReached @?= 106
       forbiddenXtz @?= 107
       proposalNotUnique @?= 108
       missigned @?= 109
@@ -39,5 +38,7 @@ test_ErrorCodes = testGroup "FA2 off-chain views"
       notDelegate @?= 120
       failDecisionLambda @?= 121
       entrypointNotFound @?= 122
+      unstakeInvalidProposal @?= 123
+      voterDoesNotExist @?= 124
       badState @?= 300
   ]

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -114,10 +114,6 @@ test_BaseDAO_Proposal =
   , testGroup "Bounded Value"
       [ testScenario "bounded value on proposals" $ scenario $
           proposalBoundedValue (originateLigoDaoWithConfigDesc dynRecUnsafe)
-
-      , testScenario "bounded value on votes" $ scenario $
-          votesBoundedValue (originateLigoDaoWithConfigDesc dynRecUnsafe)
-
       ]
 
   , testGroup "Freeze-Unfreeze"
@@ -135,6 +131,9 @@ test_BaseDAO_Proposal =
 
       , testScenario "correctly track freeze history" $ scenario $
           checkFreezeHistoryTracking (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , testScenario "tokens are unstaked correctly, only when possible" $ scenario $
+          unstakeVote (originateLigoDaoWithConfigDesc dynRecUnsafe)
       ]
 
  , testGroup "LIGO-specific proposal tests:"

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Config.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Config.hs
@@ -183,7 +183,6 @@ decisionLambdaConfig target = ConfigDesc $ passProposerOnDecision target
 instance IsConfigDescExt DAO.Config ConfigConstants where
   fillConfig ConfigConstants{..} DAO.Config{..} = DAO.Config
     { cMaxProposals = cmMaxProposals ?: cMaxProposals
-    , cMaxVoters = cmMaxVoters ?: cMaxVoters
     , cProposalFlushLevel = cmProposalFlushTime ?: cProposalFlushLevel
     , cProposalExpiredLevel = cmProposalExpiredTime ?: cProposalExpiredLevel
     , ..

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Flush.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Flush.hs
@@ -92,6 +92,9 @@ flushAcceptedProposals originateFn = do
   proposalStart <- getProposalStartLevel dodDao key1
   advanceToLevel (proposalStart + 2*dodPeriod)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
+  withSender dodOwner1 $ call dodDao (Call @"Unstake_vote") [key1]
+    & expectFailedWith voterDoesNotExist
+  withSender dodOwner2 $ call dodDao (Call @"Unstake_vote") [key1]
 
   checkIfAProposalExist key1 dodDao False
 
@@ -135,7 +138,7 @@ flushAcceptedProposalsWithAnAmount originateFn = do
   -- [Proposing]
   (key1, key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
   advanceLevel 1
-  _key3 <- createSampleProposal 3 dodOwner1 dodDao
+  key3 <- createSampleProposal 3 dodOwner1 dodDao
 
   let vote' key = NoPermit VoteParam
         { vFrom = dodOwner2
@@ -153,7 +156,7 @@ flushAcceptedProposalsWithAnAmount originateFn = do
       pure ()
 
   proposalStart2 <- getProposalStartLevel dodDao key2
-  proposalStart3 <- getProposalStartLevel dodDao key2
+  proposalStart3 <- getProposalStartLevel dodDao key3
   advanceToLevel (proposalStart2 + 21)
 
   -- [Proposing]

--- a/scripts/generate_error_code.hs
+++ b/scripts/generate_error_code.hs
@@ -65,8 +65,7 @@ invalidInputErrors = errorsEnumerate 100
     :? ("The proposal voting stage has already ended.", NoArg)
   , "max_proposals_reached"
     :? ("The maximum amount of ongoing proposals has been reached.", NoArg)
-  , "max_voters_reached"
-    :? ("The maximum amount of voters has been reached for the proposal.", NoArg)
+  , removedError
   , "forbidden_xtz"
     :? ("Transfer of XTZ is forbidden on this entrypoint.", NoArg)
   , "proposal_not_unique"
@@ -99,6 +98,10 @@ invalidInputErrors = errorsEnumerate 100
     :? ("Executing the proposal's decision lambda results in failure.", NoArg)
   , "entrypoint_not_found"
     :? ("The chosen custom entrypoint does not exist.", NoArg)
+  , "unstake_invalid_proposal"
+    :? ("Cannot call `unstake_vote` on the proposal that is not flushed or dropped.", NoArg)
+  , "voter_does_not_exist"
+    :? ("The sender did not vote on the proposal or already unstaked tokens from the proposal.", NoArg)
   ]
 
 invalidConfigErrors :: [ErrorItem]

--- a/src/base_DAO.mligo
+++ b/src/base_DAO.mligo
@@ -25,6 +25,7 @@ let requiring_no_xtz (param, store, config : forbid_xtz_params * storage * confi
     | Freeze p               -> freeze(p, config, store)
     | Unfreeze p             -> unfreeze(p, config, store)
     | Update_delegate p      -> update_delegates(p, store)
+    | Unstake_vote p         -> unstake_vote(p, config, store)
 
 (*
  * Entrypoints that allow xtz to be sent.

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -35,9 +35,6 @@ let freeze_history_constructor (acc, param : (freeze_history * nat) * (address *
 let default_config (data : initial_config_data) : config =
   let _ : unit = validate_proposal_flush_expired_level(data) in
   let _ : unit = validate_quorum_threshold_bound(data) in {
-    // TODO [#271] We have to find a safe value for max_voters
-    // and check if the value contained in the `data` is
-    // within bounds.
     proposal_check = (fun (_params, _extras : propose_params * contract_extra) -> unit);
     rejected_proposal_slash_value = (fun (_proposal, _extras : proposal * contract_extra) -> 0n);
     decision_lambda = (fun (dl_input : decision_lambda_input) ->
@@ -45,7 +42,6 @@ let default_config (data : initial_config_data) : config =
     fixed_proposal_fee_in_token = data.fixed_proposal_fee_in_token;
     period = data.period;
     max_proposals = 500n;
-    max_voters = data.max_voters;
     max_quorum_threshold = to_signed(data.max_quorum);
     min_quorum_threshold = to_signed(data.min_quorum);
     max_quorum_change = to_signed(data.max_quorum_change);
@@ -75,6 +71,7 @@ let default_storage (data, config_data : initial_storage_data * initial_config_d
     extra = (Big_map.empty : (string, bytes) big_map);
     proposals = (Big_map.empty : (proposal_key, proposal) big_map);
     proposal_key_list_sort_by_level = (Set.empty : (blocks * proposal_key) set);
+    staked_votes = (Big_map.empty : (address * proposal_key, staked_vote) big_map);
     permits_counter = 0n;
     freeze_history = freeze_history;
     frozen_token_id = frozen_token_id;

--- a/src/error_codes.mligo
+++ b/src/error_codes.mligo
@@ -32,9 +32,6 @@
 (* The maximum amount of ongoing proposals has been reached. *)
 [@inline] let max_proposals_reached = 105n
 
-(* The maximum amount of voters has been reached for the proposal. *)
-[@inline] let max_voters_reached = 106n
-
 (* Transfer of XTZ is forbidden on this entrypoint. *)
 [@inline] let forbidden_xtz = 107n
 
@@ -82,6 +79,12 @@
 
 (* The chosen custom entrypoint does not exist. *)
 [@inline] let entrypoint_not_found = 122n
+
+(* Cannot call `unstake_vote` on the proposal that is not flushed or dropped. *)
+[@inline] let unstake_invalid_proposal = 123n
+
+(* The sender did not vote on the proposal or already unstaked tokens from the proposal. *)
+[@inline] let voter_does_not_exist = 124n
 
 
 

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -51,8 +51,7 @@ type nonce = nat
 // Represents whether a voter has voted against (false) or for (true) a given proposal.
 type vote_type = bool
 
-// Stores all voter data for a proposal
-type voter_map = (address * vote_type, nat) map
+type staked_vote = nat
 
 // Amount of blocks.
 type blocks = { blocks : nat }
@@ -94,8 +93,6 @@ type proposal =
   // ^ address of the proposer
   ; proposer_frozen_token : nat
   // ^ amount of frozen tokens used by the proposer, exluding the fixed fee
-  ; voters : voter_map
-  // ^ voter data
   ; quorum_threshold: quorum_threshold
   // ^ quorum threshold at the cycle in which proposal was raised
   }
@@ -151,6 +148,7 @@ type storage =
   ; extra : contract_extra
   ; proposals : (proposal_key, proposal) big_map
   ; proposal_key_list_sort_by_level : (blocks * proposal_key) set
+  ; staked_votes : (address * proposal_key, staked_vote) big_map
   ; permits_counter : nonce
   ; freeze_history : freeze_history
   ; frozen_token_id : token_id
@@ -164,6 +162,7 @@ type storage =
 
 type freeze_param = nat
 type unfreeze_param = nat
+type unstake_vote_param = proposal_key list
 
 type transfer_ownership_param = address
 
@@ -223,6 +222,7 @@ type forbid_xtz_params =
   | Freeze of freeze_param
   | Unfreeze of unfreeze_param
   | Update_delegate of update_delegate_params
+  | Unstake_vote of unstake_vote_param
 
 (*
  * Entrypoints that allow Tz transfers
@@ -264,7 +264,6 @@ type initial_config_data =
   { max_quorum : quorum_threshold
   ; min_quorum : quorum_threshold
   ; quorum_threshold : quorum_threshold
-  ; max_voters : nat
   ; period : period
   ; proposal_flush_level: blocks
   ; proposal_expired_level: blocks
@@ -305,8 +304,6 @@ type config =
 
   ; max_proposals : nat
   // ^ Determine the maximum number of ongoing proposals that are allowed in the contract.
-  ; max_voters : nat
-  // ^ Determine the maximum number of voters allowed to vote in the context of a proposal.
   ; max_quorum_threshold : quorum_fraction
   // ^ Determine the maximum value of quorum threshold that is allowed.
   ; min_quorum_threshold : quorum_fraction

--- a/typescript/baseDAO/src/generated/Parameter.ts
+++ b/typescript/baseDAO/src/generated/Parameter.ts
@@ -7,6 +7,7 @@ import {Propose} from  './Propose';
 import {Transfer_contract_tokens} from  './Transfer_contract_tokens';
 import {Transfer_ownership} from  './Transfer_ownership';
 import {Unfreeze} from  './Unfreeze';
+import {Unstake_vote} from  './Unstake_vote';
 import {Update_delegate} from  './Update_delegate';
 import {Vote} from  './Vote';
 export type Parameter =
@@ -19,5 +20,6 @@ export type Parameter =
   | Transfer_contract_tokens
   | Transfer_ownership
   | Unfreeze
+  | Unstake_vote
   | Update_delegate
   | Vote

--- a/typescript/baseDAO/src/generated/Unstake_vote.ts
+++ b/typescript/baseDAO/src/generated/Unstake_vote.ts
@@ -1,0 +1,2 @@
+import {Lambda} from '../common';
+export type Unstake_vote = Array<string>;


### PR DESCRIPTION
## Description

Problem: The cost of proposals handling increases linearly with the
number of voters due to the fact that we unfreeze voters token on flush.

As a result, we want to to change this behavior to remove the voters
limit and avoid returning tokens on flush.

Solution: Remove returning voter tokens, remove voter limit, add
`Unfreeze_staked` entrypoints, and update the tests.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #311

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
