### PR TITLE
[#314] Improve `storage.start_level`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ $(OUT)/trivialDAO_storage.tz: src/**
             { address = (\"$(call require_defined,governance_token_address)\" : address) \
             ; token_id = ($(call require_defined,governance_token_id) : nat) \
             } \
-          ; start_level = {blocks = $(call require_defined,start_level)} \
+          ; start_level = Some {blocks = $(call require_defined,start_level)} \
           ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
           ; freeze_history = ($(call escape_double_quote,$(freeze_history)) : freeze_history_list) \
           } \
@@ -136,7 +136,7 @@ $(OUT)/registryDAO_storage.tz: src/**
               { address = (\"$(call require_defined,governance_token_address)\" : address) \
               ; token_id = ($(call require_defined,governance_token_id) : nat) \
               } \
-            ; start_level = {blocks = $(call require_defined,start_level)} \
+            ; start_level = Some {blocks = $(call require_defined,start_level)} \
             ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
             ; freeze_history = ($(call escape_double_quote,$(freeze_history)) : freeze_history_list) \
             } \
@@ -198,7 +198,7 @@ $(OUT)/treasuryDAO_storage.tz: src/**
               { address = (\"$(call require_defined,governance_token_address)\" : address) \
               ; token_id = ($(call require_defined,governance_token_id) : nat) \
               } \
-            ; start_level = {blocks = $(call require_defined,start_level)} \
+            ; start_level = Some {blocks = $(call require_defined,start_level)} \
             ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
             ; freeze_history = ($(call escape_double_quote,$(freeze_history)) : freeze_history_list) \
             } \

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -41,6 +41,7 @@ Here is a summary of all the error codes thrown by the contract.
 | 120 | `not_delegate` | The sender has not been delegated the control of the required tokens. |
 | 121 | `fail_decision_lambda` | Executing the proposal's decision lambda results in failure. |
 | 122 | `entrypoint_not_found` | The chosen custom entrypoint does not exist. |
+| 123 | `start_level_not_set` | The storage `start_level` is not set. Call `transfer_ownership` to set this. |
 
 
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -186,6 +186,10 @@ These values are:
    tokens total supply are required in total to vote for a successful proposal.
 8. `fixed_proposal_fee_in_token : nat` specifies the fee to be paid for submitting
    a proposal (in frozen tokens), if any.
+9. `start_level : blocks option` specifies the `start_level` that is used to calculate
+proposing/voting stage. Can be set at the start origination or after origination by calling
+`Transfer_ownership` which will set `start_level` to the current level of the blockchain if
+its value is `None`.
 
 # Contract logic
 
@@ -439,6 +443,8 @@ Parameter (in Michelson):
 - Initiate transfer of the role of administrator to a new address.
 
 - Fails with `NOT_ADMIN` if the sender is not the administrator.
+
+- Set storage's `start_level` to the current level of the blockchain if it is not set previously.
 
 - The current administrator retains his privileges up until
   `accept_ownership` is called, unless the proposed administrator is the DAO itself.

--- a/haskell/src/Ligo/BaseDAO/ErrorCodes.hs
+++ b/haskell/src/Ligo/BaseDAO/ErrorCodes.hs
@@ -111,6 +111,10 @@ failDecisionLambda = 121
 entrypointNotFound :: Natural
 entrypointNotFound = 122
 
+-- | The storage `start_level` is not set. Call `transfer_ownership` to set this.
+startLevelNotSet :: Natural
+startLevelNotSet = 123
+
 
 
 
@@ -267,6 +271,12 @@ tzipErrorList = [
   EStatic $ StaticError
     { seError = toExpression $ toVal @Integer $ toInteger entrypointNotFound
     , seExpansion = toExpression $ toVal @MText [mt|The chosen custom entrypoint does not exist.|]
+    , seLanguages = ["en"]
+    }
+  ,
+  EStatic $ StaticError
+    { seError = toExpression $ toVal @Integer $ toInteger startLevelNotSet
+    , seExpansion = toExpression $ toVal @MText [mt|The storage `start_level` is not set. Call `transfer_ownership` to set this.|]
     , seLanguages = ["en"]
     }
   ,

--- a/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/haskell/src/Ligo/BaseDAO/Types.hs
@@ -600,7 +600,7 @@ data Storage = Storage
   , sProposalKeyListSortByDate :: Set (Natural, ProposalKey)
   , sGovernanceToken :: GovernanceToken
   , sFreezeHistory :: BigMap Address AddressFreezeHistory
-  , sStartLevel :: Natural
+  , sStartLevel :: Maybe Natural
   , sQuorumThresholdAtCycle :: QuorumThresholdAtCycle
   , sFrozenTotalSupply :: Natural
   , sDelegates :: Delegates' BigMap
@@ -639,7 +639,7 @@ mkStorage
   :: "admin" :! Address
   -> "extra" :! ContractExtra
   -> "metadata" :! TZIP16.MetadataMap BigMap
-  -> "level" :! Natural
+  -> "level" :! Maybe Natural
   -> "tokenAddress" :! Address
   -> "quorumThreshold" :! QuorumThreshold
   -> Storage
@@ -813,7 +813,7 @@ mkFullStorage
   -> "governanceTotalSupply" :? GovernanceTotalSupply
   -> "extra" :! ContractExtra
   -> "metadata" :! TZIP16.MetadataMap BigMap
-  -> "level" :! Natural
+  -> "level" :! Maybe Natural
   -> "tokenAddress" :! Address
   -> "customEps" :? [CustomEntrypoint]
   -> FullStorage

--- a/haskell/test/SMT/Common/Gen.hs
+++ b/haskell/test/SMT/Common/Gen.hs
@@ -83,7 +83,7 @@ genStorage = do
               { gtAddress = govAddr
               , gtTokenId = FA2.theTokenId
               }
-        , sStartLevel = startLevel
+        , sStartLevel = Just startLevel
         , sQuorumThresholdAtCycle = quorumThresholdAtCycle
         , sProposals = BigMap Nothing mempty
         , sProposalKeyListSortByDate = mempty
@@ -183,7 +183,9 @@ genModelState SmtOption{..} = do
         { msFullStorage = fs
         , msMutez = toMutez 0
 
-        , msLevel = fs & fsStorage & sStartLevel
+        , msLevel = case fs & fsStorage & sStartLevel of
+            Just start -> start
+            Nothing -> error "Cannot set `msLevel` in generator."
         , msChainId = dummyChainId
         , msSelfAddress = selfAddrPlaceholder -- This will be replace when dao is originated
         , msGovernanceTokenAddress = gov

--- a/haskell/test/SMT/Common/Run.hs
+++ b/haskell/test/SMT/Common/Run.hs
@@ -63,7 +63,7 @@ runBaseDaoSMT option@SmtOption{..} = do
         let currentLevel = (dummyLevel + (ms & msLevel))
 
         let fullStorage = msFullStorage ms
-        let storage = (fsStorage fullStorage) { sStartLevel = currentLevel }
+        let storage = (fsStorage fullStorage) { sStartLevel = Just currentLevel }
 
         -- Set initial level for the Nettest
         advanceToLevel currentLevel

--- a/haskell/test/SMT/Model/BaseDAO/Proposal/FreezeHistory.hs
+++ b/haskell/test/SMT/Model/BaseDAO/Proposal/FreezeHistory.hs
@@ -25,9 +25,13 @@ getCurrentStageNum :: ModelT Natural
 getCurrentStageNum = do
   (Period vp) <- getConfig <&> cPeriod
   startLvl <- getStore <&> sStartLevel
-  lvl <- get <&> msLevel
-  case lvl `minusNaturalMaybe` startLvl of
-    Just elapsedLevel -> pure $ elapsedLevel `div` vp
+
+  case startLvl of
+    Just start -> do
+      lvl <- get <&> msLevel
+      case lvl `minusNaturalMaybe` start of
+        Just elapsedLevel -> pure $ elapsedLevel `div` vp
+        Nothing -> throwError NOT_ENOUGH_FROZEN_TOKENS
     Nothing -> error "BAD_STATE: Current lvl is smaller than `startLvl`."
 
 

--- a/haskell/test/Test/Ligo/BaseDAO/Common/StorageHelper.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Common/StorageHelper.hs
@@ -100,4 +100,8 @@ getVotePermitsCounter addr =
   (sPermitsCounterRPC . fsStorageRPC) <$> getStorageRPC addr
 
 getOriginationLevel :: forall p base caps m. MonadCleveland caps base m => TAddress p ->  m Natural
-getOriginationLevel dodDao = (sStartLevelRPC . fsStorageRPC) <$> (getStorageRPC dodDao)
+getOriginationLevel dodDao =
+  ( fromMaybe (error "getOriginationLevel: start_level is not set") .
+    sStartLevelRPC .
+    fsStorageRPC
+  ) <$> (getStorageRPC dodDao)

--- a/haskell/test/Test/Ligo/BaseDAO/ErrorCode.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/ErrorCode.hs
@@ -39,5 +39,6 @@ test_ErrorCodes = testGroup "FA2 off-chain views"
       notDelegate @?= 120
       failDecisionLambda @?= 121
       entrypointNotFound @?= 122
+      startLevelNotSet @?= 123
       badState @?= 300
   ]

--- a/haskell/test/Test/Ligo/BaseDAO/Management.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Management.hs
@@ -107,7 +107,7 @@ test_BaseDAO_Management =
       ! #admin admin
       ! #extra dynRecUnsafe
       ! #metadata mempty
-      ! #level currentLevel
+      ! #level (Just currentLevel)
       ! #tokenAddress genesisAddress
       ! #customEps
           [ ([mt|testCustomEp|], lPackValueRaw testCustomEntrypoint)

--- a/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
@@ -31,7 +31,7 @@ offChainViewStorage =
   ! #admin addr
   ! #extra dynRecUnsafe
   ! #metadata mempty
-  ! #level 100
+  ! #level (Just 100)
   ! #tokenAddress genesisAddress
   ! #quorumThreshold (mkQuorumThreshold 1 100)
   ! defaults

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Flush.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Flush.hs
@@ -120,7 +120,6 @@ flushAcceptedProposalsWithAnAmount originateFn = do
         >>- (ConfigDesc configConsts{ cmProposalFlushTime = Just 20 })
         >>- (ConfigDesc configConsts{ cmProposalExpiredTime = Just 30 })
         ) defaultQuorumThreshold
-  originationLevel <- getOriginationLevel dodDao
 
   -- [Voting]
   withSender dodOwner1 $
@@ -135,7 +134,7 @@ flushAcceptedProposalsWithAnAmount originateFn = do
   -- [Proposing]
   (key1, key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
   advanceLevel 1
-  _key3 <- createSampleProposal 3 dodOwner1 dodDao
+  key3 <- createSampleProposal 3 dodOwner1 dodDao
 
   let vote' key = NoPermit VoteParam
         { vFrom = dodOwner2
@@ -144,7 +143,7 @@ flushAcceptedProposalsWithAnAmount originateFn = do
         , vProposalKey = key
         }
 
-  advanceToLevel (originationLevel + 2 * dodPeriod)
+  advanceToLevel (startLevel + 2 * dodPeriod)
 
   -- [Voting]
   withSender dodOwner2 . inBatch $ do
@@ -153,7 +152,7 @@ flushAcceptedProposalsWithAnAmount originateFn = do
       pure ()
 
   proposalStart2 <- getProposalStartLevel dodDao key2
-  proposalStart3 <- getProposalStartLevel dodDao key2
+  proposalStart3 <- getProposalStartLevel dodDao key3
   advanceToLevel (proposalStart2 + 21)
 
   -- [Proposing]

--- a/haskell/test/Test/Ligo/RegistryDAO.hs
+++ b/haskell/test/Test/Ligo/RegistryDAO.hs
@@ -47,7 +47,7 @@ withOriginated addrCount storageFn tests = do
             { gtAddress = dodTokenContract
             , gtTokenId = FA2.theTokenId
             }
-          , sStartLevel = now_level
+          , sStartLevel = Just now_level
           }
         }
 

--- a/scripts/generate_error_code.hs
+++ b/scripts/generate_error_code.hs
@@ -99,6 +99,8 @@ invalidInputErrors = errorsEnumerate 100
     :? ("Executing the proposal's decision lambda results in failure.", NoArg)
   , "entrypoint_not_found"
     :? ("The chosen custom entrypoint does not exist.", NoArg)
+  , "start_level_not_set"
+    :? ("The storage `start_level` is not set. Call `transfer_ownership` to set this.", NoArg)
   ]
 
 invalidConfigErrors :: [ErrorItem]

--- a/src/error_codes.mligo
+++ b/src/error_codes.mligo
@@ -83,6 +83,9 @@
 (* The chosen custom entrypoint does not exist. *)
 [@inline] let entrypoint_not_found = 122n
 
+(* The storage `start_level` is not set. Call `transfer_ownership` to set this. *)
+[@inline] let start_level_not_set = 123n
+
 
 
 

--- a/src/management.mligo
+++ b/src/management.mligo
@@ -8,6 +8,8 @@
 (*
  * Auth checks for admin and store the address in parameter to the
  * `pending_owner` field in storage.
+ * Set storage's `start_level` to the current level of the blockchain if
+ * it is not set previously.
  *)
 let transfer_ownership (param, store : transfer_ownership_param * storage) : return =
   let store = authorize_admin(store) in
@@ -15,8 +17,12 @@ let transfer_ownership (param, store : transfer_ownership_param * storage) : ret
     if Tezos.self_address = param
     // If new admin is address of baseDAO, set as admin right away.
     then { store with admin = param ; }
-    else { store with pending_owner = param ; }
-  in (nil_op, store)
+    else { store with pending_owner = param ; } in
+  let store =
+    match store.start_level with
+    | Some _ -> store
+    | None -> { store with start_level = Some {blocks = Tezos.level} } in
+  (nil_op, store)
 
 (*
  * Auth check for pending admin and copies the value in `pending_owner` field

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -154,7 +154,7 @@ type storage =
   ; permits_counter : nonce
   ; freeze_history : freeze_history
   ; frozen_token_id : token_id
-  ; start_level : blocks
+  ; start_level : blocks option
   ; quorum_threshold_at_cycle : quorum_threshold_at_cycle
   ; frozen_total_supply : nat
   ; delegates : delegates
@@ -278,7 +278,7 @@ type initial_storage_data =
   { admin : address
   ; guardian : address
   ; governance_token : governance_token
-  ; start_level : blocks
+  ; start_level : blocks option
   ; metadata_map : metadata_map
   ; freeze_history : freeze_history_list
   }


### PR DESCRIPTION
## Description

Problem: The `storage.start_level` is set at the start of origination
instead of when the origination is completed. Because of this, in some
case when the origination takes longer than expected, the
`storage.start_level` is out of sync.

Solution: Provide a way to set `storage.start_level` after the
origination is completed (by calling `Transfer_ownership`). This won't
take effect if the `start_level` is already set previously.
Update the tests, and remove origination workaround.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #314

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
