### PR TITLE
[#250] fix documentation around rejected proposal slash value

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -62,12 +62,13 @@ are parameters of the contract specified by the DAO creator.
 
 Note that by setting `frozen_scale_value` to 0 it's possible to require a constant number of tokens to be locked.
 
-### Rejected proposal amount
+### Rejected proposal slash amount
 
-When a proposal is rejected, the returned amount is computed as `slash_scale_value * frozen / slash_division_value`.
+When a proposal is rejected, the amount of tokens to slash is computed as
+`slash_scale_value * frozen / slash_division_value`.
 
 `slash_scale_value` and `slash_division_value` are specified by the DAO creator.
-One can set them to 1 and 1 by default to always unfreeze all tokens.
+One can set them to 1 and 1 by default to always slash all staked tokens.
 
 ### Decision lambda
 

--- a/docs/treasury.md
+++ b/docs/treasury.md
@@ -36,9 +36,10 @@ For XTZ transfers their amount must be in range `[min_xtz_amount .. max_xtz_amou
 `max_proposal_size`, `frozen_scale_value`, `frozen_extra_value`, `min_xtz_amount` and `max_xtz_amount` are parameters of the contract specified by the DAO creator.
 Additionally, for XTZ transfers `CONTRACT unit` instruction must pass for the `recipient` address, i. e. this address must be an implicit account or refer to an entrypoint of the `unit` type.
 
-### Rejected proposal amount
+### Rejected proposal slash amount
 
-When a proposal is rejected, the returned amount is computed as `slash_scale_value * frozen / slash_division_value` just like in Registry DAO.
+When a proposal is rejected, the amount of tokens to slash is computed as
+`slash_scale_value * frozen / slash_division_value`, just like in Registry DAO.
 
 ### Decision lambda
 

--- a/docs/trivial.md
+++ b/docs/trivial.md
@@ -17,9 +17,11 @@ This DAO has no `extra` information associated to it.
 The proposal check is always successful, regardless of the content of its metadata
 or the amount of `frozen_token`s.
 
-### Rejected proposal amount
+### Rejected proposal slash amount
 
-When a proposal is rejected, the returned amount is a constant value of `0`.
+When a proposal is rejected, the amount to be slashed is a constant value of `0`.
+
+In other words, the proposer will receive back all the staked tokens.
 
 ### Decision lambda
 

--- a/src/registryDAO.mligo
+++ b/src/registryDAO.mligo
@@ -90,7 +90,7 @@ let registry_DAO_proposal_check (params, extras : propose_params * contract_extr
   | Update_contract_delegate _ -> unit
 
 (*
- * Proposal rejection return lambda: returns `slash_scale_value * frozen / slash_division_value`
+ * Proposal rejection slash lambda: returns `slash_scale_value * frozen / slash_division_value`
  * where slash_scale_value and slash_division_value are specified by the DAO creator
  * in configuration and frozen is the amount that was frozen by the proposer.
  *)

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -295,7 +295,7 @@ type config =
   // It checks 2 things: the proposal itself and the amount of tokens frozen upon submission.
   // It allows the DAO to reject a proposal by arbitrary logic and captures bond requirements
   ; rejected_proposal_slash_value : proposal * contract_extra -> nat
-  // ^ When a proposal is rejected, the value that voters get back can be slashed.
+  // ^ When a proposal is rejected, the value that the proposer gets back can be slashed.
   // This lambda returns the amount to be slashed.
   ; decision_lambda : decision_lambda
   // ^ The decision lambda is executed based on a successful proposal.


### PR DESCRIPTION
## Description

Problem: the documentation wasn't fully updated to reflect the
behavior of the rejected proposal slash value lambda, the last
time it was changed.
As a result the docs contradict each other in some cases and
don't match the actual behavior.

Solution: fix the various issues in the docs related to this
lambda and its usage.

## Related issue(s)

Fixup for #250 (and probably older issues as well)

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
