### PR TITLE
[#316] Remove proposal limit and use a linked list for sorting

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -23,7 +23,6 @@ Here is a summary of all the error codes thrown by the contract.
 | 102 | `fail_proposal_check` | Thrown paired with a `string` error message when the proposal does not pass the `proposal_check`. |
 | 103 | `proposal_not_exist` | The proposal does not exist or is no longer ongoing. |
 | 104 | `voting_stage_over` | The proposal voting stage has already ended. |
-| 105 | `max_proposals_reached` | The maximum amount of ongoing proposals has been reached. |
 | 107 | `forbidden_xtz` | Transfer of XTZ is forbidden on this entrypoint. |
 | 108 | `proposal_not_unique` | The submitted proposal already exist. |
 | 109 | `missigned` | Parameter signature does not match the expected one - for permits. |

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -92,8 +92,6 @@ type config =
   // It has access to the proposal, can modify `contractExtra` and perform arbitrary
   // operations.
 
-  ; max_proposals : nat
-  // ^ Determine the maximum number of ongoing proposals that are allowed in the contract.
   ; max_quorum_threshold : quorum_fraction
   // ^ Determine the maximum value of quorum threshold that is allowed.
   ; min_quorum_threshold : quorum_fraction
@@ -523,7 +521,6 @@ Parameter (in Michelson):
 - Fails with `NOT_PROPOSING_STAGE` if the current stage is not a proposing one.
 - Fails with `FAIL_PROPOSAL_CHECK` if the proposal is rejected by `proposal_check`
   from the configuration.
-- Fails with `MAX_PROPOSALS_REACHED` if the current amount of ongoing proposals is at max value set by the config.
 - Fails with `PROPOSAL_NOT_UNIQUE` if exactly the same proposal from the same author has been proposed.
 
 

--- a/haskell/baseDAO-ligo-meta.cabal
+++ b/haskell/baseDAO-ligo-meta.cabal
@@ -187,6 +187,7 @@ test-suite baseDAO-test
       SMT.Model.BaseDAO.Permit
       SMT.Model.BaseDAO.Proposal
       SMT.Model.BaseDAO.Proposal.FreezeHistory
+      SMT.Model.BaseDAO.Proposal.Plist
       SMT.Model.BaseDAO.Proposal.QuorumThreshold
       SMT.Model.BaseDAO.Token
       SMT.Model.BaseDAO.Types
@@ -199,6 +200,7 @@ test-suite baseDAO-test
       Test.Ligo.BaseDAO.Management
       Test.Ligo.BaseDAO.Management.TransferOwnership
       Test.Ligo.BaseDAO.OffChainViews
+      Test.Ligo.BaseDAO.Plist
       Test.Ligo.BaseDAO.Proposal
       Test.Ligo.BaseDAO.Proposal.Config
       Test.Ligo.BaseDAO.Proposal.Delegate

--- a/haskell/src/Ligo/BaseDAO/ErrorCodes.hs
+++ b/haskell/src/Ligo/BaseDAO/ErrorCodes.hs
@@ -39,10 +39,6 @@ proposalNotExist = 103
 votingStageOver :: Natural
 votingStageOver = 104
 
--- | The maximum amount of ongoing proposals has been reached.
-maxProposalsReached :: Natural
-maxProposalsReached = 105
-
 -- | Transfer of XTZ is forbidden on this entrypoint.
 forbiddenXtz :: Natural
 forbiddenXtz = 107
@@ -163,12 +159,6 @@ tzipErrorList = [
   EStatic $ StaticError
     { seError = toExpression $ toVal @Integer $ toInteger votingStageOver
     , seExpansion = toExpression $ toVal @MText [mt|The proposal voting stage has already ended.|]
-    , seLanguages = ["en"]
-    }
-  ,
-  EStatic $ StaticError
-    { seError = toExpression $ toVal @Integer $ toInteger maxProposalsReached
-    , seExpansion = toExpression $ toVal @MText [mt|The maximum amount of ongoing proposals has been reached.|]
     , seLanguages = ["en"]
     }
   ,

--- a/haskell/test/SMT/Common/Gen.hs
+++ b/haskell/test/SMT/Common/Gen.hs
@@ -86,7 +86,7 @@ genStorage = do
         , sStartLevel = startLevel
         , sQuorumThresholdAtCycle = quorumThresholdAtCycle
         , sProposals = BigMap Nothing mempty
-        , sProposalKeyListSortByDate = mempty
+        , sOngoingProposalsDlist = Nothing
         , sStakedVotes = BigMap Nothing mempty
         , sExtra = DynamicRec' mempty
 
@@ -124,8 +124,6 @@ genConfig = do
     , cGovernanceTotalSupply = governanceTotalSupply
     , cMaxQuorumThreshold = percentageToFractionNumerator 99 -- 99%
     , cMinQuorumThreshold = percentageToFractionNumerator 1 -- 1%
-
-    , cMaxProposals = 500
     }
 
 genDelegates :: GeneratorT (Map Delegate ())

--- a/haskell/test/SMT/Model/BaseDAO/Proposal/Plist.hs
+++ b/haskell/test/SMT/Model/BaseDAO/Proposal/Plist.hs
@@ -1,0 +1,128 @@
+-- SPDX-FileCopyrightText: 2021 TQ Tezos
+-- SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+-- | Common types between different DAO implementations.
+module SMT.Model.BaseDAO.Proposal.Plist
+  ( plistMem
+  , plistPop
+  , plistInsert
+  , plistDelete
+
+  , plistToList
+  , plistFromList
+  ) where
+
+import Universum
+
+import qualified Data.Map as Map
+
+import Morley.Michelson.Typed.Haskell.Value (BigMap(..))
+
+import Ligo.BaseDAO.Types
+
+plistMem :: ProposalKey -> Maybe ProposalDoublyLinkedList -> Bool
+plistMem key plistMb =
+  case plistMb of
+    Just ProposalDoublyLinkedList{..} ->
+      (plFirst == key) ||
+      (case Map.lookup (key, prev) (plMap & bmMap) of
+          Nothing -> False
+          Just _ -> True
+      )
+    Nothing -> False
+
+plistPop :: Maybe ProposalDoublyLinkedList -> (Maybe ProposalKey, Maybe ProposalDoublyLinkedList)
+plistPop plistMb =
+  case plistMb of
+    Nothing -> (Nothing, Nothing)
+    Just plist ->
+      let newPlist = case Map.lookup ((plist & plFirst), next) (plist & plMap & bmMap) of
+            Just nextKey -> Just $ plist
+              { plFirst = nextKey
+              , plMap = (plist & plMap & bmMap)
+                  & Map.delete ((plist & plFirst), next)
+                  & Map.delete (nextKey, prev)
+                  & BigMap Nothing
+              }
+            Nothing -> Nothing
+      in (Just (plist & plFirst), newPlist)
+
+plistInsert :: ProposalKey -> Maybe ProposalDoublyLinkedList -> Maybe ProposalDoublyLinkedList
+plistInsert key plistMb =
+  case plistMb of
+    Nothing ->
+      Just $ ProposalDoublyLinkedList { plFirst = key, plLast = key, plMap = mempty }
+    Just plist ->
+      Just $ plist
+        { plLast = key
+        , plMap = (plist & plMap & bmMap)
+            & Map.insert (key, prev) (plist & plLast)
+            & Map.insert ((plist & plLast), next) key
+            & BigMap Nothing
+        }
+
+plistDelete :: ProposalKey -> Maybe ProposalDoublyLinkedList -> Maybe ProposalDoublyLinkedList
+plistDelete key plistMb =
+  case plistMb of
+    Nothing ->
+      error "BAD_STATE: no proposal"
+    Just plist ->
+      -- Special case: there is a single key.
+      if (plist & plFirst) == (plist & plLast)
+      then
+        -- Either it's a different key or the list gets empty.
+        if (key == (plist & plFirst)) then Nothing else Just plist
+      else
+        let
+          -- We know that there are at least 2 keys in the list
+          -- find the keys near to key we are looking for (if any):
+          mPrevKey = Map.lookup (key, prev) (plist & plMap & bmMap)
+          mNextKey = Map.lookup (key, next) (plist & plMap & bmMap)
+
+          -- Remove both links from the map already:
+          newMap = BigMap Nothing $ Map.delete (key, prev)
+            (Map.delete (key, next) (plist & plMap & bmMap))
+
+          -- Update the next link of the prev key and find the last key
+          (newLast, newMap2) = case mPrevKey of
+            Nothing ->
+              -- There are no prev key, no changes needed
+              ((plist & plLast), newMap)
+            Just prevKey ->
+              ( (if (plist & plLast) == key then prevKey else (plist & plLast))
+              , BigMap Nothing $ Map.update (const mNextKey) (prevKey, next) (newMap & bmMap)
+              )
+
+          -- Update the prev link of the next key and find the first key
+          (newFirst, newMap3) = case mNextKey of
+            Nothing ->
+              -- There are no next key, no changes needed
+              ((plist & plFirst), newMap2)
+            Just nextKey ->
+              ( (if (plist & plFirst) == key then nextKey else (plist & plFirst))
+              , BigMap Nothing $ Map.update (const mPrevKey) (nextKey, prev) (newMap2 & bmMap)
+              )
+        in
+          Just $ ProposalDoublyLinkedList { plFirst = newFirst, plLast = newLast, plMap = newMap3 }
+
+
+-----------------------------------------------------
+-- Helper
+-----------------------------------------------------
+
+-- | Convert `Maybe ProposalDoublyLinkedList` to a list. Return empty list if input is `Nothing`.
+plistToList :: Maybe ProposalDoublyLinkedList -> [ProposalKey]
+plistToList plistMb =
+  case plistMb of
+    Nothing -> []
+    Just plist -> plistMapToList plist (plist & plFirst) []
+  where
+    plistMapToList plist key result =
+      case Map.lookup (key, next) (plist & plMap & bmMap) of
+        Nothing -> result <> [key]
+        Just nextKey -> plistMapToList plist nextKey (result <> [key])
+
+-- | Convert a list of proposal_key into `Maybe ProposalDoublyLinkedList`.
+-- Return `Nothing if input is an empty list.
+plistFromList :: [ProposalKey] -> Maybe ProposalDoublyLinkedList
+plistFromList list = foldl' (\acc el -> plistInsert el acc) Nothing list

--- a/haskell/test/SMT/Model/BaseDAO/Types.hs
+++ b/haskell/test/SMT/Model/BaseDAO/Types.hs
@@ -204,7 +204,6 @@ data ContractType
 data ModelError
   = NOT_DELEGATE
   | EMPTY_FLUSH
-  | MAX_PROPOSALS_REACHED
   | NOT_ENOUGH_FROZEN_TOKENS
   | NOT_PROPOSING_STAGE
   | PROPOSAL_NOT_UNIQUE
@@ -234,7 +233,6 @@ contractErrorToModelError :: Integer -> ModelError
 contractErrorToModelError errorCode
   | (errorCode == toInteger notDelegate) = NOT_DELEGATE
   | (errorCode == toInteger emptyFlush) = EMPTY_FLUSH
-  | (errorCode == toInteger maxProposalsReached) = MAX_PROPOSALS_REACHED
   | (errorCode == toInteger notEnoughFrozenTokens) = NOT_ENOUGH_FROZEN_TOKENS
   | (errorCode == toInteger notProposingStage) = NOT_PROPOSING_STAGE
   | (errorCode == toInteger proposalNotUnique) = PROPOSAL_NOT_UNIQUE

--- a/haskell/test/Test/Ligo/BaseDAO/ErrorCode.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/ErrorCode.hs
@@ -21,7 +21,6 @@ test_ErrorCodes = testGroup "FA2 off-chain views"
       failProposalCheck @?= 102
       proposalNotExist @?= 103
       votingStageOver @?= 104
-      maxProposalsReached @?= 105
       forbiddenXtz @?= 107
       proposalNotUnique @?= 108
       missigned @?= 109

--- a/haskell/test/Test/Ligo/BaseDAO/Plist.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Plist.hs
@@ -1,0 +1,90 @@
+-- SPDX-FileCopyrightText: 2021 TQ Tezos
+-- SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+module Test.Ligo.BaseDAO.Plist
+  ( test_Plist
+  ) where
+
+import Universum hiding (drop, swap, toList)
+
+import Data.List ((!!))
+import qualified Data.List as DL
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Test.Tasty (TestTree)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Hedgehog.Gen.Tezos.Crypto (genSecretKey)
+import Lorentz hiding (cast, concat, get, not)
+import Morley.Tezos.Address (mkKeyAddress)
+import Morley.Tezos.Crypto (toPublic)
+
+import Ligo.BaseDAO.Types
+import SMT.Model.BaseDAO.Proposal.Plist
+import Test.Ligo.BaseDAO.Common (makeProposalKey, metadataSize)
+
+{-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
+
+genProposalKeyList :: MonadGen m => Int -> m [ProposalKey]
+genProposalKeyList atLeast = do
+  i <- Gen.integral (Range.constant atLeast 10)
+  addrs <- genSecretKey
+    <&> (\secret -> mkKeyAddress . toPublic $ secret)
+    & Gen.list (Range.linear atLeast i)
+
+  pure $ (\addr ->
+      let proposalMeta = lPackValueRaw @Natural 1
+          metaSize = metadataSize proposalMeta
+          param = ProposeParams
+            { ppFrom = addr
+            , ppFrozenToken = metaSize
+            , ppProposalMetadata = proposalMeta
+            }
+      in makeProposalKey param
+    ) <$> addrs
+
+-- | Test functions that operate on `Maybe ProposalDoublyLinkedList`, and compare
+-- its result to similar function that operate on `[ProposalKey]`.
+test_Plist :: [TestTree]
+test_Plist =
+  [ testProperty "Conversion from and to `list`" $ withTests 50 $ property $ do
+      keyList <- forAll $ genProposalKeyList 0
+
+      keyList === (plistToList $ plistFromList keyList)
+
+  , testProperty "Compare `mem` function result between list and plist" $ withTests 50 $ property $ do
+      keyList <- forAll $ genProposalKeyList 1
+
+      (i :: Int) <- forAll $ Gen.integral (Range.constant 0 (length keyList - 1))
+      let k = keyList !! i
+
+      (k `elem` keyList) === (plistMem k $ plistFromList keyList)
+
+    , testProperty "Compare `insert` function result between list and plist" $ withTests 50 $ property $ do
+      keyList <- forAll $ genProposalKeyList 0
+      keyList2 <- forAll $ genProposalKeyList 1
+      (i :: Int) <- forAll $ Gen.integral (Range.constant 0 (length keyList2 - 1))
+      let k = keyList2 !! i
+
+      (keyList <> [k]) === (plistToList $ plistInsert k $ plistFromList keyList)
+
+    , testProperty "Compare `delete` function result between list and plist" $ withTests 50 $ property $ do
+      keyList <- forAll $ genProposalKeyList 1
+
+      (i :: Int) <- forAll $ Gen.integral (Range.constant 0 (length keyList - 1))
+      let k = keyList !! i
+
+      (DL.delete k keyList) === (plistToList $ plistDelete k $ plistFromList keyList)
+
+    , testProperty "Compare `pop` function result between list and plist" $ withTests 50 $ property $ do
+      keyList <- forAll $ genProposalKeyList 1
+
+      let (pFirst, pRest) = plistPop $ plistFromList keyList
+      let (lFirst, lRest) = (\case Just (f, r) -> (Just f, r); Nothing -> (Nothing, [])) $ DL.uncons $ keyList
+
+      pFirst === lFirst
+      (plistToList pRest) === lRest
+
+  ]
+

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -7,7 +7,6 @@ module Test.Ligo.BaseDAO.Proposal
   ) where
 
 import Lorentz hiding (assert, (>>))
-import Universum
 
 import Test.Cleveland
 import Test.Tasty (TestTree, testGroup)
@@ -67,7 +66,7 @@ test_BaseDAO_Proposal =
 
   -- Note: When checking storage, we need to split the test into 2 (emulator and network) as demonstrated below:
   , testScenario "cannot propose with insufficient tokens " $ scenario $
-      insufficientTokenProposal (originateLigoDaoWithConfigDesc dynRecUnsafe) (\addr -> (length . sProposalKeyListSortByDateRPC . fsStorageRPC) <$> getStorageRPC (TAddress addr))
+      insufficientTokenProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
   , testGroup "Permit:"
       [ testScenario "can vote from another user behalf" $ scenario $
@@ -109,11 +108,6 @@ test_BaseDAO_Proposal =
       , testScenario "can drop proposals, only when allowed" $ scenario $
           dropProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
-      ]
-
-  , testGroup "Bounded Value"
-      [ testScenario "bounded value on proposals" $ scenario $
-          proposalBoundedValue (originateLigoDaoWithConfigDesc dynRecUnsafe)
       ]
 
   , testGroup "Freeze-Unfreeze"

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Config.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Config.hs
@@ -83,8 +83,7 @@ ConfigDesc a >>- ConfigDesc b = ConfigDesc (ConfigDescChain a b)
 ------------------------------------------------------------------------
 
 data ConfigConstants = ConfigConstants
-  { cmMaxProposals :: Maybe Natural
-  , cmMaxVoters :: Maybe Natural
+  { cmMaxVoters :: Maybe Natural
   , cmQuorumThreshold :: Maybe DAO.QuorumThreshold
   , cmPeriod :: Maybe DAO.Period
   , cmProposalFlushTime :: Maybe Natural
@@ -95,7 +94,7 @@ data ConfigConstants = ConfigConstants
 --
 -- Example: @configConsts{ cmMaxVotes = 10 }@
 configConsts :: ConfigConstants
-configConsts = ConfigConstants Nothing Nothing Nothing Nothing Nothing Nothing
+configConsts = ConfigConstants Nothing Nothing Nothing Nothing Nothing
 
 data ProposalFrozenTokensCheck =
   ProposalFrozenTokensCheck (Lambda ("ppFrozenToken" :! Natural) ())
@@ -182,8 +181,7 @@ decisionLambdaConfig target = ConfigDesc $ passProposerOnDecision target
 --
 instance IsConfigDescExt DAO.Config ConfigConstants where
   fillConfig ConfigConstants{..} DAO.Config{..} = DAO.Config
-    { cMaxProposals = cmMaxProposals ?: cMaxProposals
-    , cProposalFlushLevel = cmProposalFlushTime ?: cProposalFlushLevel
+    { cProposalFlushLevel = cmProposalFlushTime ?: cProposalFlushLevel
     , cProposalExpiredLevel = cmProposalExpiredTime ?: cProposalExpiredLevel
     , ..
     }

--- a/scripts/generate_error_code.hs
+++ b/scripts/generate_error_code.hs
@@ -63,8 +63,7 @@ invalidInputErrors = errorsEnumerate 100
     :? ("The proposal does not exist or is no longer ongoing.", NoArg)
   , "voting_stage_over"
     :? ("The proposal voting stage has already ended.", NoArg)
-  , "max_proposals_reached"
-    :? ("The maximum amount of ongoing proposals has been reached.", NoArg)
+  , removedError
   , removedError
   , "forbidden_xtz"
     :? ("Transfer of XTZ is forbidden on this entrypoint.", NoArg)

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -41,7 +41,6 @@ let default_config (data : initial_config_data) : config =
       { operations = ([] : (operation list)); extras = dl_input.extras; guardian = (None : (address option))});
     fixed_proposal_fee_in_token = data.fixed_proposal_fee_in_token;
     period = data.period;
-    max_proposals = 500n;
     max_quorum_threshold = to_signed(data.max_quorum);
     min_quorum_threshold = to_signed(data.min_quorum);
     max_quorum_change = to_signed(data.max_quorum_change);
@@ -70,7 +69,7 @@ let default_storage (data, config_data : initial_storage_data * initial_config_d
     metadata = data.metadata_map;
     extra = (Big_map.empty : (string, bytes) big_map);
     proposals = (Big_map.empty : (proposal_key, proposal) big_map);
-    proposal_key_list_sort_by_level = (Set.empty : (blocks * proposal_key) set);
+    ongoing_proposals_dlist = (None : proposal_doubly_linked_list option);
     staked_votes = (Big_map.empty : (address * proposal_key, staked_vote) big_map);
     permits_counter = 0n;
     freeze_history = freeze_history;

--- a/src/error_codes.mligo
+++ b/src/error_codes.mligo
@@ -29,9 +29,6 @@
 (* The proposal voting stage has already ended. *)
 [@inline] let voting_stage_over = 104n
 
-(* The maximum amount of ongoing proposals has been reached. *)
-[@inline] let max_proposals_reached = 105n
-
 (* Transfer of XTZ is forbidden on this entrypoint. *)
 [@inline] let forbidden_xtz = 107n
 

--- a/src/proposal.mligo
+++ b/src/proposal.mligo
@@ -7,6 +7,7 @@
 #include "permit.mligo"
 #include "error_codes.mligo"
 #include "proposal/freeze_history.mligo"
+#include "proposal/plist.mligo"
 #include "proposal/quorum_threshold.mligo"
 
 // -----------------------------------------------------------------
@@ -25,12 +26,14 @@ let fetch_proposal (proposal_key, store : proposal_key * storage): proposal =
 [@inline]
 let check_if_proposal_exist (proposal_key, store : proposal_key * storage): proposal =
   let p = fetch_proposal (proposal_key, store) in
-  if Set.mem (p.start_level, proposal_key) store.proposal_key_list_sort_by_level
+  if plist_mem (proposal_key, store.ongoing_proposals_dlist)
     then p
     else (failwith proposal_not_exist : proposal)
 
-// Gets the current stage counting how many `period` s have passed since
-// the `start`. The stages are zero-index.
+(*
+ * Gets the current stage counting how many `period` s have passed since
+ * the `start`. The stages are zero-index.
+ *)
 let get_current_stage_num(start, vp : blocks * period) : nat =
   match is_nat((Tezos.level - start.blocks) : int) with
   | Some (elapsed_levels) -> elapsed_levels/vp.blocks
@@ -43,9 +46,11 @@ let ensure_proposal_voting_stage (proposal, period, store : proposal * period * 
   then store
   else (failwith voting_stage_over : storage)
 
-// Checks that a given stage number is a proposing stage
-// Only odd stage numbers are proposing stages, in which a proposal can be
-// submitted.
+(*
+ * Checks that a given stage number is a proposing stage
+ * Only odd stage numbers are proposing stages, in which a proposal can be
+ * submitted.
+ *)
 let ensure_proposing_stage(stage_num, store : nat * storage): storage =
   if (stage_num mod 2n) = 1n
   then store
@@ -79,8 +84,10 @@ let unstake_tk(token_amount, burn_amount, addr, period, store : nat * nat * addr
 // Delegate
 // -----------------------------------------------------------------
 
-// Check if the `author`/`sender` address is the same as `from` or a delegate of `from`.
-// Return `from` as the result.
+(*
+ * Check if the `author`/`sender` address is the same as `from` or a delegate of `from`.
+ * Return `from` as the result.
+ *)
 [@inline]
 let check_delegate (from, author, store : address * address * storage): address =
   let key: delegate = { owner = from; delegate = author } in
@@ -106,14 +113,15 @@ let update_delegates (params, store : update_delegate_params * storage): return 
   )
 
 
-// Unstake voter's tokens on a proposal that has already been flushed or dropped.
-// Fail if the voter did not vote on that proposal, or voter has already unfreezed, or
-// the proposal was not yet flushed nor dropped.
+(*
+ * Unstake voter's tokens on a proposal that has already been flushed or dropped.
+ * Fail if the voter did not vote on that proposal, or voter has already unfreezed, or
+ * the proposal was not yet flushed nor dropped.
+ *)
 let unstake_vote_one (config: config) (store , proposal_key : storage * proposal_key): storage =
 
   // Ensure proposal is already flushed or dropped.
-  let p = fetch_proposal (proposal_key, store) in
-  let _ = if Set.mem (p.start_level, proposal_key) store.proposal_key_list_sort_by_level
+  let _ = if plist_mem (proposal_key, store.ongoing_proposals_dlist)
             then (failwith unstake_invalid_proposal : unit)
             else unit in
 
@@ -130,7 +138,9 @@ let unstake_vote_one (config: config) (store , proposal_key : storage * proposal
       staked_votes = Big_map.remove (Tezos.sender, proposal_key) store.staked_votes
   }
 
-// Unstake voter's tokens on multiple proposals. Fail if an error occurred in one of the calls.
+(*
+ * Unstake voter's tokens on multiple proposals. Fail if an error occurred in one of the calls.
+ *)
 let unstake_vote (params, config, store : unstake_vote_param * config * storage): return =
   ( nil_op
   , List.fold (unstake_vote_one config) params store
@@ -140,11 +150,6 @@ let unstake_vote (params, config, store : unstake_vote_param * config * storage)
 // Propose
 // -----------------------------------------------------------------
 
-[@inline]
-let check_proposal_limit_reached (config, store : config * storage): storage =
-  if config.max_proposals <= List.length store.proposal_key_list_sort_by_level
-  then (failwith max_proposals_reached : storage)
-  else store
 
 let lock_governance_tokens (tokens, addr, frozen_total_supply, governance_token : nat * address * nat * governance_token)
     : (operation list * nat) =
@@ -198,8 +203,8 @@ let add_proposal (propose_params, period, store : propose_params * period * stor
   { store with
     proposals =
       Map.add proposal_key proposal store.proposals
-  ; proposal_key_list_sort_by_level =
-      Set.add ({blocks = Tezos.level}, proposal_key) store.proposal_key_list_sort_by_level
+  ; ongoing_proposals_dlist =
+      plist_insert (proposal_key, store.ongoing_proposals_dlist)
   }
 
 // -----------------------------------------------------------------
@@ -277,18 +282,9 @@ let do_total_vote_meet_quorum_threshold (proposal, store: proposal * storage): b
   let reached_quorum = (votes_placed * quorum_denominator) / total_supply in
   (reached_quorum >= proposal.quorum_threshold.numerator)
 
-// Delete a proposal from `proposal_key_list_sort_by_level`
-[@inline]
-let remove_from_proposal_sort_by_level
-    (level, proposal_key, store : blocks * proposal_key * storage): storage =
-  { store with proposal_key_list_sort_by_level =
-    Set.remove (level, proposal_key) store.proposal_key_list_sort_by_level
-  }
-
 let propose (param, config, store : propose_params * config * storage): return =
   let valid_from = check_delegate (param.from, Tezos.sender, store) in
   let _ : unit = config.proposal_check (param, store.extra) in
-  let store = check_proposal_limit_reached (config, store) in
   let amount_to_freeze = param.frozen_token + config.fixed_proposal_fee_in_token in
   let current_stage = get_current_stage_num(store.start_level, config.period) in
   let store = update_quorum(current_stage, store, config) in
@@ -296,65 +292,79 @@ let propose (param, config, store : propose_params * config * storage): return =
   let store = add_proposal (param, config.period, store) in
   (nil_op, store)
 
+(*
+ * Unstake proposer token and execute decision lambda based on if the proposal is passed or not.
+ *)
 [@inline]
 let handle_proposal_is_over
-    (config, start_level, proposal_key, store, ops, counter
-      : config * blocks * proposal_key * storage * operation list * counter
+    (config, proposal, store, ops
+      : config * proposal * storage * operation list
     )
-    : (operation list * storage * counter) =
-  let proposal = fetch_proposal (proposal_key, store) in
+    : (operation list * storage) =
+  let cond = do_total_vote_meet_quorum_threshold (proposal, store)
+          && proposal.upvotes > proposal.downvotes
+  in
+  let store = unstake_proposer_token
+        (config.rejected_proposal_slash_value, cond, proposal, config.period, config.fixed_proposal_fee_in_token, store) in
+  let (new_ops, store) =
+    if cond
+    then
+      let dl_out = config.decision_lambda { proposal = proposal; extras = store.extra } in
+      let guardian = match dl_out.guardian with
+        | Some g -> g
+        | None -> store.guardian
+      in (dl_out.operations,
+            { store with extra = dl_out.extras
+            ; guardian = guardian
+            })
+    else (nil_op, store)
+  in
+  let cons = fun (l, e : operation list * operation) -> e :: l in
+  let ops = List.fold cons ops new_ops in
+  (ops, store)
 
-  if is_proposal_age (proposal, config.proposal_expired_level)
-  then (failwith expired_proposal : (operation list * storage * counter))
-  else if is_proposal_age (proposal, config.proposal_flush_level)
-       && counter.current < counter.total // not finished
-  then
-    let counter = { counter with current = counter.current + 1n } in
-    let cond =    do_total_vote_meet_quorum_threshold(proposal, store)
-              && proposal.upvotes > proposal.downvotes
-    in
-    let store = unstake_proposer_token
-          (config.rejected_proposal_slash_value, cond, proposal, config.period, config.fixed_proposal_fee_in_token, store) in
-    let (new_ops, store) =
-      if cond
-      then
-        let dl_out = config.decision_lambda { proposal = proposal; extras = store.extra } in
-        let guardian = match dl_out.guardian with
-          | Some g -> g
-          | None -> store.guardian
-        in (dl_out.operations,
-              { store with extra = dl_out.extras
-              ; guardian = guardian
-              })
-      else (nil_op, store)
-    in
-    let cons = fun (l, e : operation list * operation) -> e :: l in
-    let ops = List.fold cons ops new_ops in
-    let store = remove_from_proposal_sort_by_level (start_level, proposal_key, store) in
-    (ops, store, counter)
-  else (ops, store, counter)
 
-// Flush all proposals that passed their voting stage.
+(*
+ * Flush a proposal, starting from the first. Remove it when the flush is done, and move to the next proposal.
+ *)
+let rec flush_each (n, config, store, ops : int * config * storage * operation list): (operation list * storage * int) =
+  let (plist_head, plist_new) = plist_pop store.ongoing_proposals_dlist in
+  // Ensure plist is not empty.
+  match plist_head with
+    | Some first_key ->
+        let proposal = check_if_proposal_exist (first_key, store) in
+        // Ensure the proposal is not expired.
+        let _ = if is_proposal_age (proposal, config.proposal_expired_level)
+            then (failwith expired_proposal : unit)
+            else unit in
+
+        // Ensure counter is not reached yet and the the proposal is flushable.
+        if (n > 0 && is_proposal_age (proposal, config.proposal_flush_level)) then
+          // Unstake tokens, and execute proposal's decision_lambda.
+          let (ops, store) = handle_proposal_is_over (config, proposal, store, ops) in
+          // Update the stored plist.
+          let store = { store with ongoing_proposals_dlist = plist_new } in
+          // Continue to the next proposal
+          flush_each (n - 1, config, store, ops)
+        else
+          (ops, store, n)
+    | None ->
+        (ops, store, n)
+
+(*
+ * Flush all proposals that passed their voting stage.
+ *)
 let flush(n, config, store : nat * config * storage): return =
-  if n = 0n
-  then (failwith empty_flush : return)
-  else
-    let counter : counter = { current = 0n; total = n } in
-    let flush_one
-        (acc, e: (operation list * storage * counter) * (blocks * proposal_key)) =
-          let (ops, store, counter) = acc in
-          let (start_level, proposal_key) = e in
-          handle_proposal_is_over (config, start_level, proposal_key, store, ops, counter)
-        in
-    let (ops, store, counter) =
-      Set.fold flush_one store.proposal_key_list_sort_by_level (nil_op, store, counter)
-    in
-    // prevent empty flushes to avoid gas costs when unnecessary.
-    if counter.current = 0n
-    then (failwith empty_flush : return)
-    else (ops, store)
+  let (ops, store, new_n) = flush_each (int(n), config, store, nil_op) in
 
-// Removes an accepted and finished proposal by key.
+  // prevent empty flushes to avoid gas costs when unnecessary.
+  if new_n = int(n)
+  then (failwith empty_flush : return)
+  else (ops, store)
+
+(*
+ * Removes an accepted and finished proposal by key.
+ *)
 let drop_proposal (proposal_key, config, store : proposal_key * config * storage): return =
   let proposal = check_if_proposal_exist (proposal_key, store) in
   let proposal_is_expired = is_proposal_age (proposal, config.proposal_expired_level) in
@@ -371,7 +381,10 @@ let drop_proposal (proposal_key, config, store : proposal_key * config * storage
           , config.fixed_proposal_fee_in_token
           , store
           ) in
-    let store = remove_from_proposal_sort_by_level (proposal.start_level, proposal_key, store) in
+    let store =
+          { store with ongoing_proposals_dlist =
+              plist_delete (proposal_key, store.ongoing_proposals_dlist)
+          } in
     (nil_op, store)
   else
     (failwith drop_proposal_condition_not_met : return)

--- a/src/proposal/plist.mligo
+++ b/src/proposal/plist.mligo
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2021 TQ Tezos
+// SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+#if !COMMON_PLIST_H
+#define COMMON_PLIST_H
+
+#include "../types.mligo"
+
+[@inline]
+let plist_mem (key, plist_o : proposal_key * proposal_doubly_linked_list option): bool =
+  match plist_o with
+    | None -> false
+    | Some plist ->
+        if (key = plist.first)
+          then true
+          else Map.mem (key, prev) plist.map
+
+[@inline]
+let plist_pop (plist_o : proposal_doubly_linked_list option)
+    : (proposal_key option * proposal_doubly_linked_list option) =
+  match plist_o with
+  | None ->
+    ( (None : proposal_key option)
+    , (None : proposal_doubly_linked_list option)
+    )
+  | Some plist ->
+    let new_plist = match Map.find_opt (plist.first, next) plist.map with
+      | Some next_key ->
+        Some
+          { plist with
+            first = next_key // Make the next as the first key
+          ; map =
+              Map.remove (next_key, prev) // Remove the previous link of the next key.
+                (Map.remove (plist.first, next) plist.map) // Remove the first key link.
+          }
+      | None -> (None : proposal_doubly_linked_list option) // Only the first key exist.
+    in (Some plist.first, new_plist)
+
+
+[@inline]
+let plist_insert (key, plist_o : proposal_key * (proposal_doubly_linked_list option)): proposal_doubly_linked_list option =
+  match plist_o with
+    | None -> Some
+        { first = key
+        ; last = key
+        ; map = (Big_map.empty : ((proposal_key * plist_direction), proposal_key) big_map)
+        }
+    | Some plist -> Some
+          { plist with
+            last = key
+          ; map =
+              Map.add (plist.last, next) key // Add next link of the old last key
+                (Map.add (key, prev) plist.last plist.map) // Add previous link of the new last key
+          }
+
+[@inline]
+let plist_delete (key, plist_o : proposal_key * proposal_doubly_linked_list option): proposal_doubly_linked_list option =
+  match plist_o with
+    | None ->
+        // Expect to have at least a proposal to delete it.
+        ([%Michelson ({| { FAILWITH } |} : (nat * string) -> proposal_doubly_linked_list option)]
+            (bad_state, "no proposal") : proposal_doubly_linked_list option)
+    | Some plist ->
+        // Special case: there is a single key.
+        if plist.first = plist.last
+        then
+          // Either it's a different key or the list gets empty.
+          if key = plist.first then None else Some plist
+        else
+          // We know that there are at least 2 keys in the list
+          // find the keys near to key we are looking for (if any):
+          let m_prev_key = Map.find_opt (key, prev) plist.map in
+          let m_next_key = Map.find_opt (key, next) plist.map in
+
+          // Remove both links from the map already:
+          let new_map = Big_map.remove (key, prev)
+                (Big_map.remove (key, next) plist.map) in
+
+          // Update the next link of the prev key and find the last key
+          let (new_last, new_map) = match m_prev_key with
+            | None ->
+              // There are no prev key, no changes needed
+              (plist.last, new_map)
+            | Some prev_key ->
+              ( (if plist.last = key then prev_key else plist.last)
+              , Big_map.update (prev_key, next) m_next_key new_map
+              )
+          in
+          // Update the prev link of the next key and find the first key
+          let (new_first, new_map) = match m_next_key with
+            | None ->
+              // There are no next key, no changes needed
+              (plist.first, new_map)
+            | Some next_key ->
+              ( (if plist.first = key then next_key else plist.first)
+              , Big_map.update (next_key, prev) m_prev_key new_map
+              )
+          in
+          Some { first = new_first; last = new_last; map = new_map }
+
+
+#endif // COMMON_PLIST_H included

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -36,14 +36,6 @@ type transfer_item =
   }
 type transfer_params = transfer_item list
 
-// -- Helpers -- //
-
-// Internal helper to fold up to a number
-type counter =
-  { current : nat
-  ; total : nat
-  }
-
 // -- DAO base types -- //
 
 type nonce = nat
@@ -137,7 +129,24 @@ type delegate =
   { owner : address
   ; delegate : address
   }
+
 type delegates = (delegate, unit) big_map
+
+
+// Use to query the previous and next of a proposal.
+type plist_direction = bool
+
+// Value of `plist_direction`.
+let prev = false
+let next = true
+
+// Proposal Doubly Linked List
+type proposal_doubly_linked_list =
+  [@layout:comb]
+  { first: proposal_key // First proposal_key in the list
+  ; last: proposal_key // Last proposal_key in the list. If only 1 key exist, last = first.
+  ; map: ((proposal_key * plist_direction), proposal_key) big_map
+  }
 
 type storage =
   { governance_token : governance_token
@@ -147,7 +156,7 @@ type storage =
   ; metadata : metadata_map
   ; extra : contract_extra
   ; proposals : (proposal_key, proposal) big_map
-  ; proposal_key_list_sort_by_level : (blocks * proposal_key) set
+  ; ongoing_proposals_dlist: proposal_doubly_linked_list option
   ; staked_votes : (address * proposal_key, staked_vote) big_map
   ; permits_counter : nonce
   ; freeze_history : freeze_history
@@ -302,8 +311,6 @@ type config =
   // It has access to the proposal, can modify `contractExtra` and perform arbitrary
   // operations.
 
-  ; max_proposals : nat
-  // ^ Determine the maximum number of ongoing proposals that are allowed in the contract.
   ; max_quorum_threshold : quorum_fraction
   // ^ Determine the maximum value of quorum threshold that is allowed.
   ; min_quorum_threshold : quorum_fraction


### PR DESCRIPTION
## Description

Problem: There is currently a limit on the number of concurrent ongoing proposals, due to the fact that proposals need to be sorted (for `flush`) and that this is done using a `set`, which cannot grow indefinitely without causing gas cost problems.

Solution: Remove `proposal_key_list_sort_by_level` and use a doubly linked list instead to store the proposals in order.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #316

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
