### PR TITLE
[#319] Add `plist` ligo contract, add property tests for it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ TS_OUT ?= typescript
 
 .PHONY: all clean test typescript
 
-all: $(OUT)/trivialDAO.tz $(OUT)/registryDAO.tz $(OUT)/treasuryDAO.tz
+all: $(OUT)/trivialDAO.tz $(OUT)/registryDAO.tz $(OUT)/treasuryDAO.tz $(OUT)/plist_contract.tz
 
 # Compile LIGO contract into its michelson representation.
-$(OUT)/%DAO.tz: src/**
+$(OUT)/%DAO.tz: src/**/**
 	cp src/variants/$*/implementation.mligo src/implementation.mligo
 	cp src/variants/$*/storage.mligo src/implementation_storage.mligo
 	mkdir -p $(OUT)
@@ -276,6 +276,20 @@ typescript: haskell-resources
 		STACK_DEV_OPTIONS="--fast --ghc-options -Wwarn"
 	rm -rf $(TS_OUT)/baseDAO/src/generated/*
 	stack exec -- baseDAO-ligo-meta generate-typescript --target=$(TS_OUT)/baseDAO/src/generated/
+
+$(OUT)/plist_contract.tz: haskell/test/Test/Plist/**
+	mkdir -p $(OUT)
+	# ============== Compiling contract ============== #
+	$(BUILD) haskell/test/Test/Plist/plist_contract.mligo -e plist_contract --output-file $(OUT)/plist_contract.tz
+	# ============== Compilation successful ============== #
+	# See "$(OUT)/plist_contract.tz" for compilation result #
+
+	# strip the surrounding braces and indentation,
+	# note that dollar char is escaped as part of Makefile
+	sed -i '/^ *$$/d' $(OUT)/plist_contract.tz
+	sed -i 's/^[{ ] //g' $(OUT)/plist_contract.tz
+	sed -i '$$s/[}] *$$//' $(OUT)/plist_contract.tz
+
 
 clean:
 	rm -rf $(OUT)

--- a/haskell/baseDAO-ligo-meta.cabal
+++ b/haskell/baseDAO-ligo-meta.cabal
@@ -20,6 +20,7 @@ extra-source-files:
     resources/trivialDAO_storage.tz
     resources/registryDAO_storage.tz
     resources/treasuryDAO_storage.tz
+    resources/plist_contract.tz
 extra-doc-files:
     README.md
 
@@ -220,6 +221,9 @@ test-suite baseDAO-test
       Test.Ligo.RegistryDAO.Types
       Test.Ligo.TreasuryDAO
       Test.Ligo.TreasuryDAO.Types
+      Test.Plist.Contract
+      Test.Plist.Property
+      Test.Plist.Type
       Tree
       Paths_baseDAO_ligo_meta
   hs-source-dirs:

--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -18,6 +18,7 @@ extra-source-files:
 - resources/trivialDAO_storage.tz
 - resources/registryDAO_storage.tz
 - resources/treasuryDAO_storage.tz
+- resources/plist_contract.tz
 
 description:         Tools and tests for the LIGO baseDAO contract.
 

--- a/haskell/test/Test/Ligo/BaseDAO/Common/StorageHelper.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Common/StorageHelper.hs
@@ -9,7 +9,6 @@ module Test.Ligo.BaseDAO.Common.StorageHelper
   , checkIfDelegateExists
   , getFreezeHistory
   , getFrozenTotalSupply
-  , getFullStorage
   , getProposal
   , getProposalStartLevel
   , getProposalStartLevel'

--- a/haskell/test/Test/Ligo/BaseDAO/Plist.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Plist.hs
@@ -2,7 +2,9 @@
 -- SPDX-License-Identifier: LicenseRef-MIT-TC
 
 module Test.Ligo.BaseDAO.Plist
-  ( test_Plist
+  ( genProposalKeyList
+
+  , test_Plist
   ) where
 
 import Universum hiding (drop, swap, toList)

--- a/haskell/test/Test/Plist/Contract.hs
+++ b/haskell/test/Test/Plist/Contract.hs
@@ -1,0 +1,17 @@
+-- SPDX-FileCopyrightText: 2021 Tezos Commons
+-- SPDX-License-Identifier: LicenseRef-MIT-TC
+
+module Test.Plist.Contract
+  ( plistContractLigo
+  ) where
+
+import Test.Cleveland.Lorentz (embedContract)
+import Morley.Michelson.Typed
+import qualified Lorentz as L
+
+import Test.Plist.Type
+
+plistContractLigo :: Contract (ToT PlistParameter) (ToT PlistStorage)
+plistContractLigo = L.toMichelsonContract
+  $$(embedContract @PlistParameter @PlistStorage "resources/plist_contract.tz")
+

--- a/haskell/test/Test/Plist/Property.hs
+++ b/haskell/test/Test/Plist/Property.hs
@@ -1,0 +1,134 @@
+-- SPDX-FileCopyrightText: 2021 Tezos Commons
+-- SPDX-License-Identifier: LicenseRef-MIT-TC
+
+module Test.Plist.Property
+  ( hprop_Plist
+  ) where
+
+import Universum hiding (drop, swap)
+
+import qualified Data.List as DL
+import Data.List ((!!))
+import Fmt (build, unlinesF)
+import Hedgehog hiding (assert)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import Lorentz hiding (abs, assert, and, div, not, now, (>>))
+import Test.Cleveland
+
+import Ligo.BaseDAO.Types
+import SMT.Model.BaseDAO.Proposal.Plist
+import Test.Ligo.BaseDAO.Plist (genProposalKeyList)
+import Test.Plist.Type
+import Test.Plist.Contract
+
+
+genPlistParameter :: MonadGen m => [ProposalKey] -> [ProposalKey] -> m PlistParameter
+genPlistParameter keyList keyList2 = do
+  requireExistingKeyEps <-
+    if (not $ null keyList) then do
+      (i :: Int) <- Gen.integral (Range.constant 0 (length keyList - 1))
+      let k = keyList !! i
+      pure [ Mem k
+           , Delete k
+           ]
+    else pure []
+
+  notRequireExistingKeyEps <-
+    if (not $ null keyList2) then do
+      (i2 :: Int) <- Gen.integral (Range.constant 0 (length keyList2 - 1))
+      let k2 = keyList2 !! i2
+      pure [ Insert k2
+           , Mem k2
+           , Delete k2
+           ]
+    else pure []
+
+  Gen.choice $ pure <$> (requireExistingKeyEps <> notRequireExistingKeyEps <> [Pop ()])
+
+genPlistParameters :: MonadGen m => m ([ProposalKey], [PlistParameter])
+genPlistParameters = do
+  initSize <- Gen.integral (Range.constant 0 30)
+  initSize2 <- Gen.integral (Range.constant 0 30)
+  -- Init List to be used as storage
+  keyList <- genProposalKeyList initSize
+  -- A list to pick new key from
+  keyList2 <- genProposalKeyList initSize2
+  params <- Gen.list (Range.linear 10 20) $ genPlistParameter keyList keyList2
+  pure (keyList, params)
+
+
+hprop_Plist :: Property
+hprop_Plist =
+  withTests 100 $ property $ do
+    plistTests
+
+plistTests :: PropertyT IO ()
+plistTests = do
+  (keyList, params) <- forAll genPlistParameters
+  testScenarioProps $
+    scenarioEmulated $ do
+      let defaultStore = PlistStorage (plistFromList keyList) False Nothing
+      let haskellStore = (keyList, False, Nothing)
+      -- Originate plist contract
+      plistContract <- originateTypedSimple @PlistParameter "PlistContract" defaultStore plistContractLigo
+      callContractLoop params (TAddress $ chAddress plistContract) haskellStore
+
+callContractLoop :: MonadEmulated caps base m => [PlistParameter] -> TAddress PlistParameter -> ([ProposalKey], Bool, Maybe ProposalKey) -> m ()
+callContractLoop param addr haskellStore =
+  case param of
+    p:ps -> do
+      let newHaskellStore = callHaskell haskellStore p
+      newLigoStore <- callLigo addr p
+      assert (newHaskellStore == newLigoStore) $
+        unlinesF
+          [ "━━ Error: Haskell and Ligo storage are different ━━"
+          , build p
+          , "━━ Haskell storage ━━"
+          , build newHaskellStore
+          , "━━ Ligo storage ━━"
+          , build newLigoStore
+          ]
+      callContractLoop ps addr newHaskellStore
+    [] -> pure ()
+
+-- | Call haskell implementation which uses normal list.
+callHaskell :: ([ProposalKey], Bool, Maybe ProposalKey) -> PlistParameter -> ([ProposalKey], Bool, Maybe ProposalKey)
+callHaskell (keyList, memResult, popResult) param =
+  case param of
+    Insert k ->
+      let newKeyList = if not (k `elem` keyList)
+            then keyList <> [k]
+            else keyList
+      in (newKeyList, memResult, popResult)
+    Delete k -> (DL.delete k keyList, memResult, popResult)
+    Mem k -> (keyList, k `elem` keyList, popResult)
+    Pop _ ->
+      let (list, newPopResult) = case DL.uncons keyList of
+            Just (h, r) -> (r, Just h)
+            Nothing -> ([], Nothing)
+      in (list, memResult, newPopResult)
+
+-- | Call ligo plist contract.
+callLigo :: MonadEmulated caps base m => TAddress PlistParameter -> PlistParameter -> m ([ProposalKey], Bool, Maybe ProposalKey)
+callLigo addr param = do
+  nettestResult <- attempt @TransferFailure $ case param of
+    Insert k -> do
+      PlistStorage{..} <- getFullStorage @PlistStorage (unTAddress addr)
+
+      -- Ensure that the key being inserted does not exist in the list. In the main contract, this is checked by
+      -- `check_if_proposal_exist`.
+      if (k `elem` plistToList psPlist) then
+        pure ()
+      else
+        call addr (Call @"Insert") k
+    Delete k -> call addr (Call @"Delete") k
+    Mem k -> call addr (Call @"Mem") k
+    Pop _ -> call addr (Call @"Pop") ()
+
+  case nettestResult of
+    Right _ -> do
+      PlistStorage{..} <- getFullStorage @PlistStorage (unTAddress addr)
+      pure (plistToList psPlist, psMemResult, psPopResult)
+    Left err -> error $ show err

--- a/haskell/test/Test/Plist/Type.hs
+++ b/haskell/test/Test/Plist/Type.hs
@@ -1,0 +1,47 @@
+-- SPDX-FileCopyrightText: 2021 Tezos Commons
+-- SPDX-License-Identifier: LicenseRef-MIT-TC
+
+module Test.Plist.Type
+  ( PlistParameter (..)
+  , PlistStorage (..)
+  ) where
+
+import Universum hiding (drop, swap)
+
+import Fmt (Buildable, build, genericF)
+
+import Lorentz hiding (and, div, now, (>>))
+
+import Ligo.BaseDAO.Types
+
+
+data PlistParameter
+  = Insert ProposalKey
+  | Delete ProposalKey
+  | Mem ProposalKey
+  | Pop ()
+  deriving stock (Eq, Show)
+
+instance Buildable PlistParameter where
+  build = genericF
+
+customGeneric "PlistParameter" ligoLayout
+deriving anyclass instance IsoValue PlistParameter
+instance ParameterHasEntrypoints PlistParameter where
+  type ParameterEntrypointsDerivation PlistParameter = EpdDelegate
+
+data PlistStorage = PlistStorage
+  { psPlist :: (Maybe ProposalDoublyLinkedList)
+  , psMemResult :: Bool
+  , psPopResult :: Maybe ProposalKey
+  }
+
+customGeneric "PlistStorage" ligoLayout
+
+deriving stock instance Show PlistStorage
+deriving stock instance Eq PlistStorage
+deriving anyclass instance IsoValue PlistStorage
+instance HasAnnotation PlistStorage where
+  annOptions = baseDaoAnnOptions
+instance Buildable PlistStorage where
+  build = genericF

--- a/haskell/test/Test/Plist/plist_contract.mligo
+++ b/haskell/test/Test/Plist/plist_contract.mligo
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2021 Tezos Commons
+// SPDX-License-Identifier: LicenseRef-MIT-TC
+
+#include "../../../../src/common/types.mligo"
+#include "../../../../src/proposal/plist.mligo"
+
+type plist_parameter =
+  | Insert of proposal_key
+  | Delete of proposal_key
+  | Mem of proposal_key
+  | Pop of unit
+
+type plist_storage =
+  { plist : (proposal_doubly_linked_list option)
+  ; mem_result: bool
+  ; pop_result: proposal_key option
+  }
+
+let plist_contract (param, store : plist_parameter * plist_storage)
+    : operation list * plist_storage =
+  let new_store = match param with
+        | Insert k -> { store with plist = plist_insert (k, store.plist) }
+        | Delete k -> { store with plist = plist_delete (k, store.plist) }
+        | Mem k    -> { store with
+            mem_result = plist_mem (k, store.plist)
+          }
+        | Pop _    ->
+            let (pop_result, plist) = plist_pop store.plist
+            in { store with plist = plist ; pop_result = pop_result}
+  in (nil_op, new_store)

--- a/src/proposal/plist.mligo
+++ b/src/proposal/plist.mligo
@@ -57,9 +57,8 @@ let plist_insert (key, plist_o : proposal_key * (proposal_doubly_linked_list opt
 let plist_delete (key, plist_o : proposal_key * proposal_doubly_linked_list option): proposal_doubly_linked_list option =
   match plist_o with
     | None ->
-        // Expect to have at least a proposal to delete it.
-        ([%Michelson ({| { FAILWITH } |} : (nat * string) -> proposal_doubly_linked_list option)]
-            (bad_state, "no proposal") : proposal_doubly_linked_list option)
+        // Do nothing in case of no proposal key.
+        plist_o
     | Some plist ->
         // Special case: there is a single key.
         if plist.first = plist.last

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -138,7 +138,13 @@ type plist_direction = bool
 let prev = false
 let next = true
 
-// Proposal Doubly Linked List
+(*
+ * Proposal Doubly Linked List
+ *
+ * Behave like `OrderedSet`.
+ * When inserting a new key, it should be ensured that the key does not exist in the list or else
+ * it will corrupt the data structure.
+ *)
 type proposal_doubly_linked_list =
   [@layout:comb]
   { first: proposal_key // First proposal_key in the list


### PR DESCRIPTION

## Description

Problem: Currently, we only tests plist utility functions one at
a time. It may be helpful to test combinations of them at the same time.

Solution: Add `plist` ligo contract, and add property tests for it
by comparing it with haskell list implementation.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #319

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
