### PR TITLE
[#322] Switch to bigmaps to store registry in registryDAO

### DIFF
--- a/haskell/src/Ligo/BaseDAO/RegistryDAO/Types.hs
+++ b/haskell/src/Ligo/BaseDAO/RegistryDAO/Types.hs
@@ -4,8 +4,11 @@
 module Ligo.BaseDAO.RegistryDAO.Types
   ( RegistryCustomEpParam (..)
   , RegistryExtra (..)
+  , RegistryExtraRPC (..)
   , RegistryStorage
   , LookupRegistryParam (..)
+  , RegistryKey
+  , RegistryValue
   ) where
 
 import Universum hiding (fromInteger)
@@ -59,8 +62,8 @@ type RegistryKey = MText
 type RegistryValue = MText
 
 data RegistryExtra = RegistryExtra
-  { reRegistry :: Map RegistryKey RegistryValue
-  , reRegistryAffected :: Map RegistryKey ProposalKey
+  { reRegistry :: BigMap RegistryKey RegistryValue
+  , reRegistryAffected :: BigMap RegistryKey ProposalKey
   , reProposalReceivers :: Set Address
   , reFrozenScaleValue :: Natural
   , reFrozenExtraValue :: Natural
@@ -71,17 +74,35 @@ data RegistryExtra = RegistryExtra
   , reMaxXtzAmount :: Mutez
   } deriving stock (Eq)
 
+-- We manually derive RPC counterpart of RegistryExtra now.
+-- TODO: Revert this once https://gitlab.com/morley-framework/morley/-/issues/754
+-- is resolved.
+data RegistryExtraRPC = RegistryExtraRPC
+  { reRegistryRPC :: BigMapId RegistryKey RegistryValue
+  , reRegistryAffectedRPC :: BigMapId RegistryKey ProposalKey
+  , reProposalReceiversRPC :: Set Address
+  , reFrozenScaleValueRPC :: Natural
+  , reFrozenExtraValueRPC :: Natural
+  , reMaxProposalSizeRPC :: Natural
+  , reSlashScaleValueRPC :: Natural
+  , reSlashDivisionValueRPC :: Natural
+  , reMinXtzAmountRPC :: Mutez
+  , reMaxXtzAmountRPC :: Mutez
+  }
+
+instance HasRPCRepr RegistryExtra where
+  type AsRPC RegistryExtra = RegistryExtraRPC
+
 instance Default RegistryExtra where
-  def = RegistryExtra M.empty M.empty S.empty 1 0 1000 1 1 zeroMutez [tz|1u|]
+  def = RegistryExtra (mkBigMap @(Map RegistryKey RegistryValue) M.empty) (mkBigMap @(Map RegistryKey ProposalKey) M.empty) S.empty 1 0 1000 1 1 zeroMutez [tz|1u|]
 
 instance Buildable RegistryExtra where
   build = genericF
 
-instance HasRPCRepr RegistryExtra where
-  type AsRPC RegistryExtra = RegistryExtra
-
 customGeneric "RegistryExtra" ligoLayout
+customGeneric "RegistryExtraRPC" ligoLayout
 deriving anyclass instance IsoValue RegistryExtra
+deriving anyclass instance IsoValue RegistryExtraRPC
 instance HasAnnotation RegistryExtra where
   annOptions = baseDaoAnnOptions
 

--- a/haskell/test/Test/Ligo/RegistryDAO.hs
+++ b/haskell/test/Test/Ligo/RegistryDAO.hs
@@ -32,7 +32,7 @@ import Ligo.BaseDAO.Types
 import Test.Ligo.BaseDAO.Common
 import Test.Ligo.RegistryDAO.Types
 
-getStorageRPCRegistry :: forall p caps vd m. MonadCleveland caps m => TAddress p vd ->  m (StorageSkeletonRPC (VariantToExtra 'Registry))
+getStorageRPCRegistry :: forall p caps vd m. MonadCleveland caps m => TAddress p vd ->  m (StorageSkeletonRPC (AsRPC (VariantToExtra 'Registry)))
 getStorageRPCRegistry addr = getStorage @(StorageSkeleton (VariantToExtra 'Registry)) (unTAddress addr)
 
 withOriginated
@@ -262,7 +262,7 @@ test_RegistryDAO =
               withSender admin $
                 call baseDao (Call @"Flush") (1 :: Natural)
 
-              maxProposalSize <- (reMaxProposalSize . sExtraRPC) <$> getStorageRPCRegistry baseDao
+              maxProposalSize <- (reMaxProposalSizeRPC . sExtraRPC) <$> getStorageRPCRegistry baseDao
               assert (maxProposalSize == 341) "Unexpected max_proposal_size update"
 
     , testScenario "checks on-chain view correctly returns the registry value" $ scenario $ do
@@ -651,7 +651,7 @@ test_RegistryDAO =
             advanceToLevel (proposalStart + 2*period)
             withSender admin $ call baseDao (Call @"Flush") (1 :: Natural)
 
-            receiversSet <- (reProposalReceivers . sExtraRPC) <$> getStorageRPCRegistry baseDao
+            receiversSet <- (reProposalReceiversRPC . sExtraRPC) <$> getStorageRPCRegistry baseDao
             assert ((wallet1 `S.member` receiversSet) && (wallet2 `S.member` receiversSet))
               "Proposal receivers was not updated as expected"
 
@@ -701,7 +701,7 @@ test_RegistryDAO =
             advanceToLevel (proposalStart + 2*period)
             withSender admin $ call baseDao (Call @"Flush") (1 :: Natural)
 
-            receiversSet <- (reProposalReceivers . sExtraRPC) <$> getStorageRPCRegistry baseDao
+            receiversSet <- (reProposalReceiversRPC . sExtraRPC) <$> getStorageRPCRegistry baseDao
             assert (Prelude.not (wallet1 `S.member` receiversSet))
               "Proposal receivers was not updated as expected"
     ]
@@ -727,8 +727,8 @@ test_RegistryDAO =
 
     initialStorageWithExplictRegistryDAOConfig :: Address -> RegistryStorage
     initialStorageWithExplictRegistryDAOConfig admin = (initialStorage admin)
-      & setExtra (\re -> re { reRegistry = M.empty })
-      & setExtra (\re -> re { reRegistryAffected = M.empty })
+      & setExtra (\re -> re { reRegistry = mempty })
+      & setExtra (\re -> re { reRegistryAffected = mempty })
       & setExtra (\re -> re { reProposalReceivers = S.empty })
       & setExtra (\re -> re { reFrozenScaleValue = 1 })
       & setExtra (\re -> re { reFrozenExtraValue = 0 })

--- a/src/variants/registry/implementation.mligo
+++ b/src/variants/registry/implementation.mligo
@@ -20,7 +20,7 @@ let apply_diff_registry (diff, registry : registry_diff * registry) : registry =
   let
     foldFn (registry, update: registry * (registry_key * registry_value option)) : registry =
       let (registry_key, registry_value) = update in
-      Map.update registry_key registry_value registry
+      Big_map.update registry_key registry_value registry
   in List.fold foldFn diff registry
 
 let apply_diff_registry_affected
@@ -30,7 +30,7 @@ let apply_diff_registry_affected
     foldFn (registry_affected, update: registry_affected * (registry_key *
       registry_value option)) : registry_affected =
       let registry_key = update.0 in
-      Map.update registry_key (Some (proposal_key)) registry_affected
+      Big_map.update registry_key (Some (proposal_key)) registry_affected
   in List.fold foldFn diff registry_affected
 
 let apply_diff (diff, ce : registry_diff * contract_extra) : contract_extra =

--- a/src/variants/registry/storage.mligo
+++ b/src/variants/registry/storage.mligo
@@ -6,13 +6,12 @@
 
 type registry_key = string
 type registry_value = string
-type registry = (registry_key, registry_value) map
+type registry = (registry_key, registry_value) big_map
 type proposal_key = bytes
 
-type registry = (registry_key, registry_value) map
 type contract_extra =
   { registry : registry
-  ; registry_affected : (registry_key, proposal_key) map
+  ; registry_affected : (registry_key, proposal_key) big_map
   ; proposal_receivers : address set
   ; frozen_scale_value : nat
   ; frozen_extra_value : nat
@@ -24,8 +23,8 @@ type contract_extra =
   }
 
 let default_extra : contract_extra =
-  { registry = (Map.empty : registry)
-  ; registry_affected = (Map.empty : (registry_key, proposal_key) map)
+  { registry = (Big_map.empty : registry)
+  ; registry_affected = (Big_map.empty : (registry_key, proposal_key) big_map)
   ; proposal_receivers = (Set.empty : address set)
   ; frozen_scale_value = 1n
   ; frozen_extra_value = 0n

--- a/src/variants/registry/types.mligo
+++ b/src/variants/registry/types.mligo
@@ -8,8 +8,8 @@
 type registry_key = string
 type registry_value = string
 
-type registry = (registry_key, registry_value) map
-type registry_affected = (registry_key, proposal_key) map
+type registry = (registry_key, registry_value) big_map
+type registry_affected = (registry_key, proposal_key) big_map
 type registry_diff = (registry_key * registry_value option) list
 type proposal_receivers = address set
 


### PR DESCRIPTION
Problem: We think it might be better for registryDAO to store registry
and registry affected maps in a BigMap instead of a Map

Solution: Amend the record to change these two fields to a BigMap and
make corresponding changes to the LIGO and Haskell tests.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
