### PR TITLE
[#329] Fix lambdadao test timing

### DIFF
--- a/haskell/test/Test/Ligo/LambdaDAO.hs
+++ b/haskell/test/Test/Ligo/LambdaDAO.hs
@@ -54,6 +54,7 @@ withOriginated addrCount storageFn tests = do
     , uodStorage = untypeValue $ toVal storage
     , uodContract = convertContract baseDAOLambdaLigo
     }
+  advanceToLevel now_level
   tests addresses storage (TAddress baseDao) (TAddress dodTokenContract)
 
 toPeriod :: LambdaStorage -> Natural

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -12,9 +12,9 @@ let validate_proposal_flush_expired_level (data : initial_config_data) : unit =
   else unit
 
 let validate_quorum_threshold_bound (data : initial_config_data) : unit =
-  if data.quorum_threshold >= data.max_quorum then
+  if data.quorum_threshold > data.max_quorum then
     failwith("'quorum_threshold' needs to be smaller than or equal to 'max_quorum'")
-  else if data.quorum_threshold <= data.min_quorum then
+  else if data.quorum_threshold < data.min_quorum then
     failwith("'quorum_threshold' needs to be bigger than or equal to 'min_quorum'")
   else
     unit


### PR DESCRIPTION
## Description

Add a wait period to origination procedure of LambdaDAO tests to ensure that we are past `start-level` before returning from the function. Also fixes a small error in the bound checking of quorum threshold.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves: CI test failures and fixes a small bug in quorum threshold bounds check

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
