### PR TITLE
[#339] Initialize registry for registry contracts during storage build

### DIFF
--- a/src/variants/lambdaregistry/implementation.mligo
+++ b/src/variants/lambdaregistry/implementation.mligo
@@ -106,6 +106,8 @@ let default_lambda_registry_DAO_storage (data : initial_registryDAO_storage) : s
     ; ("slash_division_value", Bytes.pack data.slash_division_value)
     ; ("min_xtz_amount", Bytes.pack data.min_xtz_amount)
     ; ("max_xtz_amount", Bytes.pack data.max_xtz_amount)
+    ; ("registry", Bytes.pack (Map.empty : registry))
+    ; ("registry_affected", Bytes.pack (Map.empty : registry_affected))
     ] in
   { store with
     extra =


### PR DESCRIPTION
## Description


Problem: In the build process for storage for registry contract, we are not initializing registry key in the contract extra field. This causes registry operations to error out after a fresh deploy.

Solution: Initialize registry key in contract extra duing the build.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #339

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
